### PR TITLE
Add CORS and simple client/server auth

### DIFF
--- a/.github/workflows/prod_url_check.yml
+++ b/.github/workflows/prod_url_check.yml
@@ -3,6 +3,8 @@ name: PROD_URL_CHECK
 on:
     pull_request:
       branches: [ main ]
+      paths:
+        - 'client/src/App.js'
 
 jobs:
     check-url:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 credentials/token.js
 server/credentials/token.js
 package-lock.json
+client/src/credentials/token.js

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,8 +21,8 @@ function MilpacRequest() {
   useEffect(() => {
     async function fetchMilpacList() {
       try {
-        //const requestUrl = 'https://bff.adr.7cav.us/roster/combat'
-        const requestUrl = 'http://localhost:4000/roster/combat'    //Use this for local hosting
+        const requestUrl = 'https://bff.adr.7cav.us/roster/combat'
+        //const requestUrl = 'http://localhost:4000/roster/combat'    //Use this for local hosting
         const response = await fetch(requestUrl, {
           headers: {
             'Authorization': CLIENT_TOKEN
@@ -45,8 +45,8 @@ function MilpacRequest() {
   useEffect(() => {
     async function fetchReserveList() {
       try {
-        //const requestUrl = 'https://bff.adr.7cav.us/roster/reserves'
-        const requestUrl = 'http://localhost:4000/roster/reserves'    //Use this for local hosting
+        const requestUrl = 'https://bff.adr.7cav.us/roster/reserves'
+        //const requestUrl = 'http://localhost:4000/roster/reserves'    //Use this for local hosting
         const response = await fetch(requestUrl, {
           headers: {
             'Authorization': CLIENT_TOKEN

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,7 @@ import './App.css';
 import Collapsible from 'react-collapsible';
 import lists from './modules/Generic/BilletBank';
 import MilpacParse from './modules/Generic/MilpacParse';
+import CLIENT_TOKEN from './credentials/token';
 // import {Helmet} from 'react-helmet';
 
 function MilpacRequest() {
@@ -20,9 +21,13 @@ function MilpacRequest() {
   useEffect(() => {
     async function fetchMilpacList() {
       try {
-        const requestUrl = 'https://bff.adr.7cav.us/roster/combat'
-        //const requestUrl = 'http://localhost:4000/roster/combat'    //Use this for local hosting
-        const response = await fetch(requestUrl);
+        //const requestUrl = 'https://bff.adr.7cav.us/roster/combat'
+        const requestUrl = 'http://localhost:4000/roster/combat'    //Use this for local hosting
+        const response = await fetch(requestUrl, {
+          headers: {
+            'Authorization': CLIENT_TOKEN
+          }
+        });
 
         if (!response.ok) {
           throw new Error('HTTP Error! status: ' + response.status);
@@ -40,9 +45,13 @@ function MilpacRequest() {
   useEffect(() => {
     async function fetchReserveList() {
       try {
-        const requestUrl = 'https://bff.adr.7cav.us/roster/reserves'
-        //const requestUrl = 'http://localhost:4000/roster/reserves'    //Use this for local hosting
-        const response = await fetch(requestUrl);
+        //const requestUrl = 'https://bff.adr.7cav.us/roster/reserves'
+        const requestUrl = 'http://localhost:4000/roster/reserves'    //Use this for local hosting
+        const response = await fetch(requestUrl, {
+          headers: {
+            'Authorization': CLIENT_TOKEN
+          }
+        });
 
         if (!response.ok) {
           throw new Error('HTTP Error! status: ' + response.status);

--- a/client/src/credentials/example_token.js
+++ b/client/src/credentials/example_token.js
@@ -1,6 +1,5 @@
-const API_TOKEN = 'XXXXXXXXXXX'
 const CLIENT_TOKEN = 'XXXXXXXX'
-module.exports = { API_TOKEN, CLIENT_TOKEN };
+module.exports = CLIENT_TOKEN;
 
 
 //rename this file as "token.js" when in use.

--- a/client/src/credentials/example_token.js
+++ b/client/src/credentials/example_token.js
@@ -3,4 +3,4 @@ module.exports = CLIENT_TOKEN;
 
 
 //rename this file as "token.js" when in use.
-// should be in `../server/credentials/token.js` path.
+// should be in `../client/src/credentials/token.js` path.

--- a/config/client/deployment.yml
+++ b/config/client/deployment.yml
@@ -18,7 +18,14 @@ spec:
           image: <IMAGE>
           ports:
             - containerPort: 8080
-
+          volumeMounts:
+            - name: token
+              mountPath: /app/client/src/credentials
+              readOnly: true
+      volumes:
+        - name: token
+          secret:
+            secretName: adr-client-token
 ---
 apiVersion: v1
 kind: Service
@@ -48,17 +55,17 @@ metadata:
 spec:
   tls:
     - hosts:
-      - "adr.7cav.us"
+        - "adr.7cav.us"
       secretName: letsencrypt-adr-client
   ingressClassName: nginx
   rules:
-  - host: adr.7cav.us
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: adr-client
-            port:
-              name: http
+    - host: adr.7cav.us
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: adr-client
+                port:
+                  name: http

--- a/config/server/deployment.yml
+++ b/config/server/deployment.yml
@@ -25,7 +25,7 @@ spec:
       volumes:
         - name: token
           secret:
-            secretName: adr-token
+            secretName: adr-server-token
 ---
 apiVersion: v1
 kind: Service
@@ -55,17 +55,17 @@ metadata:
 spec:
   tls:
     - hosts:
-      - "bff.adr.7cav.us"
+        - "bff.adr.7cav.us"
       secretName: letsencrypt-adr-server
   ingressClassName: nginx
   rules:
-  - host: bff.adr.7cav.us
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: adr-server
-            port:
-              name: http
+    - host: bff.adr.7cav.us
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: adr-server
+                port:
+                  name: http

--- a/server/controllers/cacheManager.js
+++ b/server/controllers/cacheManager.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const Token = require("../credentials/token");
+const { API_TOKEN } = require("../credentials/token");
 
 let cachedCombatRoster;
 let cachedReserveRoster;
@@ -11,7 +11,7 @@ const updateCombatRosterCache = async () => {
             headers: {
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
-                Authorization: 'Bearer ' + Token
+                Authorization: 'Bearer ' + API_TOKEN
             },
         });
         cachedCombatRoster = response.data;
@@ -27,7 +27,7 @@ const updateReserveRosterCache = async () => {
             headers: {
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
-                Authorization: 'Bearer ' + Token
+                Authorization: 'Bearer ' + API_TOKEN
             },
         });
         cachedReserveRoster = response.data;

--- a/server/server.js
+++ b/server/server.js
@@ -3,13 +3,36 @@ const express = require("express");
 const app = express()
 const cors = require("cors");
 const port = 4000;
+const { CLIENT_TOKEN } = require("./credentials/token");
+
+const corsOptions = {
+  origin: function (origin, callback) {
+    const allowlist = ["http://localhost:3000", "http://adr.7cav.us", "https://adr.7cav.us", "https://adr.7cav.us/"];
+    if (allowlist.indexOf(origin) !== -1 || !origin) {
+      callback(null, true);
+    } else {
+      callback(new Error("Not allowed by CORS"));
+    }
+  }
+}
+
+// Token Checking Middleware
+const checkToken = (req, res, next) => {
+  const authToken = req.headers['authorization'];
+  if (authToken === CLIENT_TOKEN) {
+    next();  // proceed to the next middleware or route handler
+  } else {
+    res.status(403).send('Forbidden');
+  }
+};
 
 app.use(cors({
-  origin: '*',
+  origin: corsOptions.origin,
 }));
-app.use("/roster", middleware);
+// Apply token checking middleware only to these routes
+app.use("/roster", checkToken, middleware);
 app.get("/", (req, res) => {
-  res.send("Ayy Lmao! Successful response! Any issues? Submit a ticket to S6!");
+  res.send("Server Test Page Loaded Successfully. Any issues? Submit a ticket to S6! Frontend is at https://adr.7cav.us/");
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
Nothing here is truly needing security but this will limit some potential automation from hitting our stuff as easily.

When merged this will:
1. Setup serverside CORS policy to only allow requests from adr.7cav.us and localhost:3000 for dev simplicity
2. Setup simple client/server authentication to prevent exposing full api calls on the server, while still allowing the server test page to be publicly visible.

TODO:
- [x] update deployment yamls to properly mount new client secret
- [x] update secrets on k8s cluster to include new token for client and server