### PR TITLE
Add dependabot config with weekly cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Dependabot config — weekly cadence with a 7-day cooldown so version bumps
+# wait for supply-chain-attack flagging before hitting the review queue.
+# Minor + patch updates are grouped per ecosystem to keep PR volume down;
+# major bumps land as individual PRs so they get scrutinized on their own.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      client-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+      - "client"
+
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      server-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+      - "server"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering all four dependency surfaces in the repo: npm (`/client`, `/server`), github-actions, and docker.
- Weekly cadence with a 7-day `cooldown` so version bumps wait long enough for supply-chain-attack flagging before landing on the review queue, but don't stagnate.
- Minor + patch updates are grouped per ecosystem to keep PR volume down; major bumps land as individual PRs so they get scrutinized on their own.

## Test plan
- [ ] Merge and confirm Dependabot picks up the config (Insights → Dependency graph → Dependabot)
- [ ] First weekly run lands grouped minor/patch PRs (if any pending) with the configured labels