### PR TITLE
Self-host Prettier via root package.json; drop creyD/prettier_action

### DIFF
--- a/.github/workflows/lint_format.yml
+++ b/.github/workflows/lint_format.yml
@@ -1,28 +1,26 @@
-# This is a basic workflow to help you get started with Actions
-
 name: LINT_FORMAT_CHECK
 
-# Controls when the workflow will run
 on:
   pull_request:
     branches:
       - main
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # deployment
   lint_format_check:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout the Repo
         uses: actions/checkout@v6
 
-      - name: Prettier
-        uses: creyD/prettier_action@v4.3
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
-          prettier_options: "--check {**/*,*}.{js,jsx,json,html,css}"
-          prettier_version: "2.8.8"
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prettier check
+        run: npm run format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+client/.next
+client/node_modules
+client/package-lock.json
+server/node_modules
+server/package-lock.json
+node_modules
+package-lock.json

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -33,9 +33,20 @@
 :root {
   background-color: #111111;
   margin: 0;
-  font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji",
-    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family:
+    "Roboto",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    "Noto Sans",
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji";
 
   font-weight: 400;
   font-size: 13px;

--- a/client/app/reusableModules/getIndividual.jsx
+++ b/client/app/reusableModules/getIndividual.jsx
@@ -16,7 +16,7 @@ export default async function GetIndividual(userName) {
   if (response.status != 200) {
     if (response.status == 404) {
       throw new Error(
-        `User Not Found. All requests must follow the specified format (Lastname.F)`
+        `User Not Found. All requests must follow the specified format (Lastname.F)`,
       );
     }
   }

--- a/client/app/rosterstatistics/page.jsx
+++ b/client/app/rosterstatistics/page.jsx
@@ -10,7 +10,7 @@ const Statistics = dynamic(
   () => import("../rosterstatistics/modules/statistics"),
   {
     ssr: false,
-  }
+  },
 );
 
 export const metadata = {

--- a/client/app/uniformbuilder/modules/AwardClasses.jsx
+++ b/client/app/uniformbuilder/modules/AwardClasses.jsx
@@ -266,7 +266,7 @@ export class BadgeCombat extends Badge {
 
   updateBadgeCombat(newAwardData, AwardRegistry) {
     const registryDetails = AwardRegistry.getAwardDetails(
-      newAwardData.awardName
+      newAwardData.awardName,
     );
     const newAwardPriority = registryDetails.awardPriority;
 

--- a/client/app/uniformbuilder/modules/GetUserInfo.jsx
+++ b/client/app/uniformbuilder/modules/GetUserInfo.jsx
@@ -9,7 +9,7 @@ export default function GetUserInfo(
   ribbonCount,
   citationCount,
   yearsInService,
-  tabCount
+  tabCount,
 ) {
   const returnObject = {
     nameTag: generateNameTag(dataActive.user.username),
@@ -34,7 +34,7 @@ export default function GetUserInfo(
   returnObject.combatBadgeCoords = GetCombatBadgeCoords(ribbonCount);
   returnObject.yearsInServiceCoordArray = GetYearsInServiceCoordArray(
     yearsInService,
-    getRankGrade(dataActive.rank.rankId)
+    getRankGrade(dataActive.rank.rankId),
   );
   returnObject.tabCoordArray = GetTabCoordArray(tabCount);
 

--- a/client/app/uniformbuilder/modules/canvas.jsx
+++ b/client/app/uniformbuilder/modules/canvas.jsx
@@ -36,23 +36,23 @@ function Canvas(props) {
       loadImage("/skunkworks/uniformBase/uniformBase.png", "uniformBase"),
       loadImage(
         "/skunkworks/uniformBase/uniformRightLapel.png",
-        "uniformLapel"
+        "uniformLapel",
       ),
       loadImage(
         `skunkworks/uniformEpaulettes/${data[0].rankGrade}.png`,
-        "uniformEpaulette"
+        "uniformEpaulette",
       ),
       loadImage(
         "skunkworks/uniformRibbons/ribbons/ribbonSpriteSheet.png",
-        "ribbonSprites"
+        "ribbonSprites",
       ),
       loadImage(
         "skunkworks/uniformRibbons/ribbons/unitCitationSprite.png",
-        "citationSprites"
+        "citationSprites",
       ),
       loadImage(
         "skunkworks/uniformMedals/medalSpriteSheet.png",
-        "medalSprites"
+        "medalSprites",
       ),
       loadImage("skunkworks/uniformTabs/tabSpriteSheet.png", "tabSprites"),
     ];
@@ -61,8 +61,8 @@ function Canvas(props) {
       imagePromises.push(
         loadImage(
           `skunkworks/uniformBadges/combatBadges/${data[4].imageNum}.png`,
-          "uniformCombatBadge"
-        )
+          "uniformCombatBadge",
+        ),
       );
     }
 
@@ -105,7 +105,7 @@ function Canvas(props) {
           desiredX,
           desiredY,
           ribbonWidth,
-          ribbonHeight
+          ribbonHeight,
         );
       };
 
@@ -128,7 +128,7 @@ function Canvas(props) {
             desiredX,
             desiredY,
             ribbonWidth,
-            ribbonHeight
+            ribbonHeight,
           );
           resolve(); // Resolve AFTER drawing BOTH ribbon and attachment
         };
@@ -164,7 +164,7 @@ function Canvas(props) {
           desiredX,
           desiredY,
           ribbonWidth,
-          ribbonHeight
+          ribbonHeight,
         );
       };
 
@@ -184,7 +184,7 @@ function Canvas(props) {
             desiredX,
             desiredY,
             ribbonWidth,
-            ribbonHeight
+            ribbonHeight,
           );
           resolve(); // Resolve AFTER drawing BOTH ribbon and attachment
         };
@@ -237,7 +237,7 @@ function Canvas(props) {
           xCoord,
           yCoord,
           ribbonWidth,
-          ribbonHeight
+          ribbonHeight,
         );
       };
 
@@ -260,7 +260,7 @@ function Canvas(props) {
             xCoord + 13,
             yCoord + 7,
             ribbonWidth,
-            ribbonHeight
+            ribbonHeight,
           );
           resolve(); // Resolve AFTER drawing BOTH ribbon and attachment
         };
@@ -286,7 +286,7 @@ function Canvas(props) {
       };
       img.onerror = () => {
         console.error(
-          `Error loading special award image: skunkworks/uniformSpecialMedals/${data.awardPriority}.png`
+          `Error loading special award image: skunkworks/uniformSpecialMedals/${data.awardPriority}.png`,
         );
         resolve(); // Resolve even on error
       };
@@ -326,7 +326,7 @@ function Canvas(props) {
             userData.yearsInServiceCoordArray[i].dx,
             userData.yearsInServiceCoordArray[i].dy,
             stripeWidth,
-            stripeHeight
+            stripeHeight,
           );
         }
         resolve();
@@ -334,7 +334,7 @@ function Canvas(props) {
 
       img.onerror = () => {
         console.error(
-          `Error loading service stripe image: skunkworks/uniformService/${userData.yearsInServiceCoordArray[0]}/serviceStripe.png`
+          `Error loading service stripe image: skunkworks/uniformService/${userData.yearsInServiceCoordArray[0]}/serviceStripe.png`,
         );
         resolve(); // Resolve even on error
       };
@@ -374,7 +374,7 @@ function Canvas(props) {
           dx,
           dy,
           tagWidth,
-          tagHeight
+          tagHeight,
         );
         if (userData.nameTag.length > 10) {
           fontSize = 18 - (userData.nameTag.length - 10) * 2;
@@ -390,7 +390,7 @@ function Canvas(props) {
 
       img.onerror = () => {
         console.error(
-          `Error loading name tag: skunkworks/uniformNameTag/${selector}.png`
+          `Error loading name tag: skunkworks/uniformNameTag/${selector}.png`,
         );
         resolve(); // Resolve even on error
       };
@@ -419,7 +419,7 @@ function Canvas(props) {
           dx,
           rootY,
           rootWidth,
-          rootHeight
+          rootHeight,
         );
 
         const initialPlateY = rootY + rootHeight - 10;
@@ -440,13 +440,13 @@ function Canvas(props) {
                 dx,
                 currentPlateY,
                 plateWidth,
-                plateHeight
+                plateHeight,
               );
               resolvePlate(); // Resolve the plate promise when the image is loaded and drawn
             };
             img2.onerror = () => {
               console.error(
-                `Error loading weapon qual plate: skunkworks/uniformWeaponQuals/plates/${data[i]}.png`
+                `Error loading weapon qual plate: skunkworks/uniformWeaponQuals/plates/${data[i]}.png`,
               );
               resolvePlate();
             };
@@ -462,7 +462,7 @@ function Canvas(props) {
 
       img.onerror = () => {
         console.error(
-          `Error loading weapon qual root: skunkworks/uniformWeaponQuals/root/${selector}.png`
+          `Error loading weapon qual root: skunkworks/uniformWeaponQuals/root/${selector}.png`,
         );
         resolve();
       };
@@ -489,7 +489,7 @@ function Canvas(props) {
           desiredX,
           desiredY,
           tabWidth,
-          tabHeight
+          tabHeight,
         );
       };
 
@@ -541,8 +541,8 @@ function Canvas(props) {
                 ribbonData,
                 images.ribbonSprites,
                 data[0].ribbonCoordArray[index],
-                context
-              )
+                context,
+              ),
             ),
           ...data[2]
             .slice(0, data[0].unitCitationCount)
@@ -551,14 +551,14 @@ function Canvas(props) {
                 ribbonData,
                 images.citationSprites,
                 data[0].unitCitationCoordArray[index],
-                context
-              )
+                context,
+              ),
             ),
           placeInfantryBadge(
             // Include the infantry badge promise here
             images.uniformCombatBadge,
             data[0].combatBadgeCoords,
-            context
+            context,
           ),
         ]);
 
@@ -578,7 +578,7 @@ function Canvas(props) {
         try {
           if (data[0].nameTag.length > 15)
             throw new Error(
-              "Name Tag exceeds allowable length. You must add the name tag manually in the .xcf file."
+              "Name Tag exceeds allowable length. You must add the name tag manually in the .xcf file.",
             );
           await Promise.all([placeNameTag(data[0], context)]);
         } catch (err) {
@@ -625,7 +625,7 @@ function Canvas(props) {
 
             if (checksum != uniqueEntries.size) {
               throw new Error(
-                "Weapon Qual Checksum Failed. This is due to a double entry in the Milpac and cannot be fixed by you. Inform your lead if you see this error."
+                "Weapon Qual Checksum Failed. This is due to a double entry in the Milpac and cannot be fixed by you. Inform your lead if you see this error.",
               );
             }
 
@@ -648,8 +648,8 @@ function Canvas(props) {
                   activeQuals.data,
                   xPositions[index],
                   activeQuals.type,
-                  context
-                )
+                  context,
+                ),
               ),
             ]);
           }
@@ -666,8 +666,8 @@ function Canvas(props) {
                 tabData,
                 images.tabSprites,
                 data[0].tabCoordArray[index],
-                context
-              )
+                context,
+              ),
             ),
           ]);
         }
@@ -685,7 +685,7 @@ function Canvas(props) {
             await Promise.all([
               placeCordPins(
                 `skunkworks/uniformCords/${data[0].shoulderCord}.png`,
-                context
+                context,
               ),
             ]);
           }
@@ -696,7 +696,7 @@ function Canvas(props) {
             await Promise.all([
               placeCordPins(
                 `skunkworks/uniformLapelPins/${data[0].neckPins}.png`,
-                context
+                context,
               ),
             ]);
           }
@@ -749,7 +749,7 @@ function Canvas(props) {
           }
 
           let _offsetX = Math.floor(
-            offsetX + 4 + x * (medalWidth + medalSpacing)
+            offsetX + 4 + x * (medalWidth + medalSpacing),
           );
           let _offsetY = offsetY + y * rowSpacing;
 
@@ -800,7 +800,7 @@ function Canvas(props) {
         // Draw medals in reverse row order (row 3, then 2, then 1)
         await Promise.all([
           ...specialMedals.map((medalData) =>
-            drawSpecialMedal(medalData, context)
+            drawSpecialMedal(medalData, context),
           ),
         ]);
         await Promise.all([
@@ -810,8 +810,8 @@ function Canvas(props) {
               images.medalSprites,
               context,
               medalCoordsRow3[index].x,
-              medalCoordsRow3[index].y
-            )
+              medalCoordsRow3[index].y,
+            ),
           ),
         ]);
         await Promise.all([
@@ -821,8 +821,8 @@ function Canvas(props) {
               images.medalSprites,
               context,
               medalCoordsRow2[index].x,
-              medalCoordsRow2[index].y
-            )
+              medalCoordsRow2[index].y,
+            ),
           ),
         ]);
 
@@ -833,8 +833,8 @@ function Canvas(props) {
               images.medalSprites,
               context,
               medalCoordsRow1[index].x,
-              medalCoordsRow1[index].y
-            )
+              medalCoordsRow1[index].y,
+            ),
           ),
         ]);
 

--- a/client/app/uniformbuilder/modules/getCanvasObject.jsx
+++ b/client/app/uniformbuilder/modules/getCanvasObject.jsx
@@ -73,7 +73,7 @@ export default async function GetCanvasObject(userName) {
         existingAward = awardMap.get(key);
       }
 
-      if (!existingAward instanceof Ribbon) {
+      if ((!existingAward) instanceof Ribbon) {
         continue;
       }
 
@@ -119,7 +119,7 @@ export default async function GetCanvasObject(userName) {
           case "RibbonDonationLogic":
             const newRibbonDonation = new RibbonDonationLogic(
               data.awards[i],
-              AwardRegistryInstance
+              AwardRegistryInstance,
             );
             awardMap.set(key, newRibbonDonation);
             totalRibbonCount++;
@@ -132,7 +132,7 @@ export default async function GetCanvasObject(userName) {
           case "MedalTiered":
             const newTiered = new MedalTiered(
               data.awards[i],
-              AwardRegistryInstance
+              AwardRegistryInstance,
             );
             awardMap.set(key, newTiered);
             totalRibbonCount++;
@@ -140,7 +140,7 @@ export default async function GetCanvasObject(userName) {
           case "MedalWithValor":
             const newMedalWithValor = new MedalWithValor(
               data.awards[i],
-              AwardRegistryInstance
+              AwardRegistryInstance,
             );
             awardMap.set(key, newMedalWithValor);
             totalRibbonCount++;
@@ -148,7 +148,7 @@ export default async function GetCanvasObject(userName) {
           case "UnitCitation":
             const newUnitCitation = new UnitCitation(
               data.awards[i],
-              AwardRegistryInstance
+              AwardRegistryInstance,
             );
             awardMap.set(key, newUnitCitation);
             totalUnitCitationCount++;
@@ -157,14 +157,14 @@ export default async function GetCanvasObject(userName) {
             const newBadgeCombat = new BadgeCombat(
               data.awards[i],
               data.mos,
-              AwardRegistryInstance
+              AwardRegistryInstance,
             );
             awardMap.set("BadgeCombat", newBadgeCombat);
             break;
           case "WeaponQual":
             const newWeaponQual = new WeaponQual(
               data.awards[i],
-              AwardRegistryInstance
+              AwardRegistryInstance,
             );
             awardMap.set("WeaponQual", newWeaponQual);
             break;
@@ -187,7 +187,7 @@ export default async function GetCanvasObject(userName) {
     totalRibbonCount,
     totalUnitCitationCount,
     yearsInService,
-    tabCount
+    tabCount,
   );
 
   const arr = [];

--- a/client/app/uniformbuilder/modules/getCoordArray.jsx
+++ b/client/app/uniformbuilder/modules/getCoordArray.jsx
@@ -26,7 +26,7 @@ export default function GetCoordArray(numAwards) {
 
   if (numAwards >= 35)
     throw new Error(
-      "FATAL ERROR! The number of ribbons of this user exceeds the max allowable limit. This is a priority error. Inform your lead, S1 1IC and 2IC with the name of the affected user."
+      "FATAL ERROR! The number of ribbons of this user exceeds the max allowable limit. This is a priority error. Inform your lead, S1 1IC and 2IC with the name of the affected user.",
     );
 
   /* included for use later

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "adr",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "adr",
+      "devDependencies": {
+        "prettier": "3.8.3"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "adr",
+  "private": true,
+  "scripts": {
+    "format:check": "prettier --check \"{**/*,*}.{js,jsx,json,html,css}\"",
+    "format": "prettier --write \"{**/*,*}.{js,jsx,json,html,css}\""
+  },
+  "devDependencies": {
+    "prettier": "3.8.3"
+  }
+}

--- a/server/controllers/cacheManager.js
+++ b/server/controllers/cacheManager.js
@@ -72,7 +72,7 @@ const updateCachedIndividual = async (userName) => {
           Authorization: "Bearer " + API_TOKEN,
           "Accept-Encoding": "gzip",
         },
-      }
+      },
     );
     cachedIndividual = response.data;
     cacheTime["individual"] = Date.now();
@@ -96,7 +96,7 @@ const updateCachedGroups = async () => {
           Authorization: "Bearer " + API_TOKEN,
           "Accept-Encoding": "gzip",
         },
-      }
+      },
     );
     cachedGroups = response.data;
     cacheTime["individual"] = Date.now();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -10,7 +10,7 @@ const app = express();
 app.use(
   cors({
     origin: "*",
-  })
+  }),
 );
 
 router.get("/combat", cRequest);

--- a/server/server.js
+++ b/server/server.js
@@ -53,7 +53,7 @@ app.use((req, res, next) => {
     console.log(
       `${new Date().toISOString()} | ${req.method} ${req.originalUrl} | ${
         res.statusCode
-      } | ${duration}ms | origin=${req.headers["origin"] || "-"}`
+      } | ${duration}ms | origin=${req.headers["origin"] || "-"}`,
     );
   });
   next();
@@ -64,13 +64,13 @@ app.use(compression());
 app.use(
   cors({
     origin: corsOptions.origin,
-  })
+  }),
 );
 // Apply token checking middleware only to these routes
 app.use("/roster", checkToken, middleware);
 app.get("/", (req, res) => {
   res.send(
-    "Server Test Page Loaded Successfully. Any issues? Submit a ticket to S6! Frontend is at https://apps.7cav.us/"
+    "Server Test Page Loaded Successfully. Any issues? Submit a ticket to S6! Frontend is at https://apps.7cav.us/",
   );
 });
 


### PR DESCRIPTION
## Why

`creyD/prettier_action@v4.6` silently broke the `prettier_version` input — instead of installing the pinned version, it falls back to whatever current is on npm (3.8.3 today). That's how the lint job blew up when Dependabot bumped the action (we reverted back to v4.3 to fix it). We're one shaky third-party update away from this recurring.

This PR removes that fragility by pinning Prettier in our own lockfile and dropping the third-party action.

## What changed

- New root `package.json` with `prettier` as a single devDep + `format` / `format:check` scripts
- New `.prettierignore` covering build outputs and lockfiles
- Workflow swaps `creyD/prettier_action@v4.3` → `npm ci && npm run format:check` (with `actions/setup-node@v6` + npm cache)
- One-time Prettier 3 reformat across 11 files — entirely the v3 `trailingComma: "all"` default change + long font-family list wrapping in `globals.css`. Verified by spot-checking diffs: no semantic changes.

## Both devs

Local usage is now:
```
npm install     # once
npm run format  # write
npm run format:check  # match CI
```

Same Prettier version everywhere, locked in `package-lock.json`. Dependabot will propose future Prettier bumps as normal PRs with a visible reformat diff.

## Implicit resolution

Resolves the `creyD/prettier_action 4.3 → 4.6` half of #117 — the action is no longer referenced.

## Test plan

- [x] `npm run format:check` clean locally
- [x] `client/npm run build` compiles successfully (pre-existing `/adr` + `/rosterstatistics` prerender errors are unchanged from main)
- [x] CI lint_format_check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)