### PR TITLE
fix(uniformbuilder): render aviator badge for MOS 155F

### DIFF
--- a/client/app/uniformbuilder/modules/AwardClasses.jsx
+++ b/client/app/uniformbuilder/modules/AwardClasses.jsx
@@ -201,7 +201,8 @@ export class BadgeCombat extends Badge {
       this.userMos == "153A" ||
       this.userMos == "155A" ||
       this.userMos == "15A" ||
-      this.userMos == "15T"
+      this.userMos == "15T" ||
+      this.userMos == "155F"
     ) {
       this.isAviation = true;
     }
@@ -246,7 +247,7 @@ export class BadgeCombat extends Badge {
       }
     }
 
-    if (this.isAviation && (this.userMos == "15T" || this.userMos == "155F")) {
+    if (this.isAviation && this.userMos == "15T") {
       switch (num) {
         case 6:
           return 10;


### PR DESCRIPTION
## Problem

A member with MOS **155F** rendered the **Flight Medic Badge** in the Uniform Builder instead of an Aviator badge.

**Root cause:** `155F` was missing from the `isAviation` list in `BadgeCombat`'s constructor (`AwardClasses.jsx`). With `isAviation` false, both aviation branches in `getImageNum` were skipped and priority-6 fell through to image 6 (Flight Medic Badge).

## Fix

- Add `155F` to the `isAviation` list so it is recognized as aviation.
- Remove the now-redundant `155F` from the aircrew (`== "15T"`) branch of `getImageNum`.

With `isAviation` true and `mos != "15T"`, 155F resolves through the regular-aviator branch to image numbers **7-9**.

## Behavior

| MOS | Before | After |
|-----|--------|-------|
| 155F | Flight Medic Badge (img 6) | Regular aviator wings (img 7-9) |
| 15T | Aircrew wings (10-12) | Aircrew wings (10-12) — unchanged |
| 153A / 155A / 15A | Aviator wings (7-9) | Aviator wings (7-9) — unchanged |