### PR TITLE
Restore uniform builder username autocomplete

### DIFF
--- a/client/app/reusableModules/searchForUser.jsx
+++ b/client/app/reusableModules/searchForUser.jsx
@@ -1,0 +1,27 @@
+const CLIENT_TOKEN = process.env.NEXT_PUBLIC_CLIENT_TOKEN;
+const BASE_URL = process.env.NEXT_PUBLIC_USERCACHE_API_URL;
+
+export default async function searchForUser(query) {
+  const url = new URL(BASE_URL);
+
+  url.searchParams.append("q", query);
+  const fullIndividualApiUrl = url.toString();
+
+  const response = await fetch(fullIndividualApiUrl, {
+    headers: {
+      Authorization: CLIENT_TOKEN,
+    },
+    cache: "no-store",
+  });
+
+  if (response.status != 200) {
+    throw new Error(`User search failed: ${response.status}`);
+  }
+
+  try {
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    throw new Error(`Invalid JSON response: ${error.message}`);
+  }
+}

--- a/client/app/reusableModules/searchForUser.jsx
+++ b/client/app/reusableModules/searchForUser.jsx
@@ -25,7 +25,11 @@ export default async function searchForUser(query) {
 
   try {
     const data = await response.json();
-    return Array.isArray(data) ? data : [];
+    if (!Array.isArray(data)) {
+      console.error("User search returned non-array payload", data);
+      return [];
+    }
+    return data;
   } catch (error) {
     throw new Error(`Invalid JSON response: ${error.message}`);
   }

--- a/client/app/reusableModules/searchForUser.jsx
+++ b/client/app/reusableModules/searchForUser.jsx
@@ -2,6 +2,11 @@ const CLIENT_TOKEN = process.env.NEXT_PUBLIC_CLIENT_TOKEN;
 const BASE_URL = process.env.NEXT_PUBLIC_USERCACHE_API_URL;
 
 export default async function searchForUser(query) {
+  if (!BASE_URL)
+    throw new Error("NEXT_PUBLIC_USERCACHE_API_URL is not configured");
+  if (!CLIENT_TOKEN)
+    throw new Error("NEXT_PUBLIC_CLIENT_TOKEN is not configured");
+
   const url = new URL(BASE_URL);
 
   url.searchParams.append("q", query);
@@ -20,7 +25,7 @@ export default async function searchForUser(query) {
 
   try {
     const data = await response.json();
-    return data;
+    return Array.isArray(data) ? data : [];
   } catch (error) {
     throw new Error(`Invalid JSON response: ${error.message}`);
   }

--- a/client/app/uniformbuilder/page.jsx
+++ b/client/app/uniformbuilder/page.jsx
@@ -66,20 +66,27 @@ export default function Skunkworks() {
   };
 
   useEffect(() => {
-    const fetchSuggestions = async () => {
-      if (userName.length >= 3 && userName !== submittedUserName) {
-        try {
-          const data = await searchForUser(userName);
-          setSuggestions(data);
-        } catch (err) {
+    if (!(userName.length >= 3 && userName !== submittedUserName)) {
+      setSuggestions([]);
+      return;
+    }
+    let ignore = false;
+    const t = setTimeout(async () => {
+      try {
+        const data = await searchForUser(userName);
+        if (!ignore) setSuggestions(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (!ignore) {
           console.error("Suggestion fetch failed", err);
+          setSuggestions([]);
         }
-      } else {
-        setSuggestions([]);
       }
+    }, 200);
+    return () => {
+      ignore = true;
+      clearTimeout(t);
     };
-    fetchSuggestions();
-  }, [userName]);
+  }, [userName, submittedUserName]);
 
   useEffect(() => {
     if (submittedUserName) {
@@ -88,7 +95,6 @@ export default function Skunkworks() {
         setLoading(true);
         setError(null);
         try {
-          console.log(submittedUserName);
           const data = await GetCanvasObject(submittedUserName);
           setCanvasData(data);
         } catch (err) {

--- a/client/app/uniformbuilder/page.jsx
+++ b/client/app/uniformbuilder/page.jsx
@@ -7,23 +7,79 @@ import UniformText from "../theme/uniformBuilderText";
 import Canvas from "./modules/canvas";
 import "./page.css";
 import Loading from "../adr/loading";
+import searchForUser from "../reusableModules/searchForUser";
 
 export default function Skunkworks() {
   const [userName, setUserName] = useState("");
   const [canvasData, setCanvasData] = useState(null);
+  const [suggestions, setSuggestions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [submittedUserName, setSubmittedUserName] = useState(""); // Track submitted username
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [suggestions]);
 
   const handleInputChange = (event) => {
     setUserName(event.target.value);
   };
 
   const handleInputKeyDown = (event) => {
-    if (event.key === "Enter") {
-      setSubmittedUserName(userName); // Update submitted username on Enter
+    if (suggestions.length > 0) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((prev) =>
+          prev < suggestions.length - 1 ? prev + 1 : prev,
+        );
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((prev) => (prev > 0 ? prev - 1 : prev));
+      } else if (
+        (event.key === "Enter" || event.key === "ArrowRight") &&
+        activeIndex !== -1
+      ) {
+        event.preventDefault();
+        const selectedName = suggestions[activeIndex];
+        if (selectedName !== "...") {
+          selectUser(selectedName);
+        }
+      } else if (event.key === "Enter") {
+        setSubmittedUserName(userName);
+        setSuggestions([]);
+      }
+    } else if (event.key === "Enter") {
+      setSubmittedUserName(userName);
     }
   };
+
+  const suggestionClicked = (name) => {
+    setSuggestions([]);
+    selectUser(name);
+  };
+
+  const selectUser = (name) => {
+    setSuggestions([]);
+    setUserName(name);
+    setSubmittedUserName(name);
+  };
+
+  useEffect(() => {
+    const fetchSuggestions = async () => {
+      if (userName.length >= 3 && userName !== submittedUserName) {
+        try {
+          const data = await searchForUser(userName);
+          setSuggestions(data);
+        } catch (err) {
+          console.error("Suggestion fetch failed", err);
+        }
+      } else {
+        setSuggestions([]);
+      }
+    };
+    fetchSuggestions();
+  }, [userName]);
 
   useEffect(() => {
     if (submittedUserName) {
@@ -46,7 +102,7 @@ export default function Skunkworks() {
     } else {
       setCanvasData(null);
     }
-  }, [submittedUserName]); // Effect runs when submittedUserName changes
+  }, [submittedUserName]);
 
   return (
     <div className="masterboxbuilder">
@@ -63,21 +119,41 @@ export default function Skunkworks() {
         </div>
       </div>
       <div className="inputboxbuilder">
-        <input
-          type="text"
-          value={userName}
-          onChange={handleInputChange}
-          onKeyDown={handleInputKeyDown} // Add key down handler
-          placeholder="Please enter a 7Cav Username e.g Doe.J"
-        />
-        {
-          //!submittedUserName && (
-          //<div>Please enter a username and press Enter.</div>
-          //)
-        }
+        <div className="inputboxflex">
+          <input
+            type="text"
+            value={userName}
+            onChange={handleInputChange}
+            onKeyDown={handleInputKeyDown}
+            placeholder="Please enter a 7Cav Username e.g Doe.J"
+          />
+          {suggestions.length > 0 && (
+            <div className="suggestions-container">
+              {suggestions.map((name, index) => (
+                <div
+                  key={index}
+                  className={`${
+                    name === "..." ? "suggestion-more" : "suggestion-item"
+                  } ${index === activeIndex ? "active" : ""}`}
+                  style={{ animationDelay: `${index * 0.03}s` }}
+                  onClick={() => name !== "..." && suggestionClicked(name)}
+                >
+                  {name}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
       {loading && <Loading />}
-      {error && <div>Error: {error.message}</div>}
+      {error && (
+        <div className="canvasboxbuilder">
+          <div className="errorbox">
+            <h3 className="errorheader">Network Error!</h3>
+            {error.message}
+          </div>
+        </div>
+      )}
       {canvasData && !loading && !error && (
         <div className="canvasboxbuilder">
           <Canvas data={canvasData} />


### PR DESCRIPTION
## What this does

Restores the username autocomplete on the uniform builder (`/uniformbuilder`). As you type a 7Cav username (3+ characters), a suggestions dropdown appears. You can navigate the suggestions with the keyboard:

- **ArrowDown / ArrowUp** move through the list
- **Enter / ArrowRight** select the highlighted suggestion
- **Enter** with nothing highlighted submits the typed value
- Clicking a suggestion also selects it

This feature was previously reverted (commit `581727d`) during a cleanup and was not carried back during the recent integration. This change re-adds it.

It also fixes two pre-existing bugs in `client/app/reusableModules/searchForUser.jsx`:
- the error path referenced an undefined variable (`throw Error(e)`), now throws a real error with the response status
- an unreachable `return data;` after the try/catch was removed

## Dependencies

This relies on the `/userSearch` backend endpoint, which is **already merged into `main`**. No backend changes are included in this PR.

## Deployment

The client must have the env var `NEXT_PUBLIC_USERCACHE_API_URL` set to the `/userSearch` endpoint URL. This is the same server as `NEXT_PUBLIC_DIFF_API_URL`, but with the `/userSearch` path. Without this variable set, the suggestions fetch will fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)