### PR TITLE
Rosterhistory: fast heatmap tooltips (#137) + unit-visibility empty states (#136)

### DIFF
--- a/client/app/rosterhistory/components/HistoryView.jsx
+++ b/client/app/rosterhistory/components/HistoryView.jsx
@@ -459,12 +459,14 @@ export function HistoryView() {
             presentRosterTypes={presentRosterTypes}
           />
 
-          <UnitFilterBar
-            events={typeFilteredEvents}
-            unitFilter={unitFilter}
-            onSelect={handleUnitSelect}
-            onClear={handleUnitClear}
-          />
+          {!isLoading && (
+            <UnitFilterBar
+              events={typeFilteredEvents}
+              unitFilter={unitFilter}
+              onSelect={handleUnitSelect}
+              onClear={handleUnitClear}
+            />
+          )}
 
           {activeData?.counts && (
             <SummaryBar
@@ -504,16 +506,21 @@ export function HistoryView() {
             <p className="text-muted-foreground text-sm">Loading…</p>
           )}
 
-          {!isError && !isLoading && totalVisible === 0 && (
-            <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
-              <p>
-                No changes{" "}
-                {selectedDay
-                  ? "recorded for this date."
-                  : "in the selected range."}
-              </p>
-            </div>
-          )}
+          {/* When a unit filter matched nothing, UnitFilterBar renders its own
+              explanatory empty state — skip the generic message. */}
+          {!isError &&
+            !isLoading &&
+            totalVisible === 0 &&
+            !unitFilter.battalion && (
+              <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
+                <p>
+                  No changes{" "}
+                  {selectedDay
+                    ? "recorded for this date."
+                    : "in the selected range."}
+                </p>
+              </div>
+            )}
 
           {notable.length > 0 && (
             <div className="space-y-2">

--- a/client/app/rosterhistory/components/HistoryView.jsx
+++ b/client/app/rosterhistory/components/HistoryView.jsx
@@ -11,6 +11,12 @@ import {
 import { Download, Search, X, ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useDiffList, useDiffRange, useDiffByDate, useRanks } from "../lib/api";
 import { DiffEventCard } from "./DiffEventCard";
@@ -369,24 +375,31 @@ export function HistoryView() {
                 : "day"}{" "}
             to drill down
           </p>
-          <div className="flex flex-wrap gap-1">
-            {heatmapData.map((entry) => {
-              const count = totalCount(entry);
-              const isSelected = entry.date === selectedDay;
-              return (
-                <button
-                  key={entry.date}
-                  title={`${entry.label}: ${count} change${count !== 1 ? "s" : ""}`}
-                  onClick={() => handleDotClick(entry)}
-                  className={cn(
-                    "h-4 w-4 rounded-sm transition-transform hover:scale-125 hover:ring-2 hover:ring-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    heatIntensity(count, maxCount),
-                    isSelected && "ring-2 ring-primary scale-125",
-                  )}
-                />
-              );
-            })}
-          </div>
+          <TooltipProvider delayDuration={100}>
+            <div className="flex flex-wrap gap-1">
+              {heatmapData.map((entry) => {
+                const count = totalCount(entry);
+                const isSelected = entry.date === selectedDay;
+                return (
+                  <Tooltip key={entry.date}>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => handleDotClick(entry)}
+                        className={cn(
+                          "h-4 w-4 rounded-sm transition-transform hover:scale-125 hover:ring-2 hover:ring-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          heatIntensity(count, maxCount),
+                          isSelected && "ring-2 ring-primary scale-125",
+                        )}
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {`${entry.label}: ${count} change${count !== 1 ? "s" : ""}`}
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </TooltipProvider>
           <div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
             <span>Less</span>
             {[

--- a/client/app/rosterhistory/components/HistoryView.jsx
+++ b/client/app/rosterhistory/components/HistoryView.jsx
@@ -108,7 +108,10 @@ export function HistoryView() {
     return s;
   }, [activeData]);
 
-  const typeFilteredEvents = useMemo(
+  // Events with every filter EXCEPT the unit predicate applied. Used to
+  // decide whether an active unit filter is the actual cause of an empty
+  // view (vs. event-type/roster-type filters having emptied it already).
+  const preUnitFilteredEvents = useMemo(
     () =>
       (activeData?.events ?? []).filter((e) => {
         if (!activeFilters.has(e.event_type)) return false;
@@ -119,25 +122,26 @@ export function HistoryView() {
           return false;
         if (e.roster_type && !activeRosterTypes.has(e.roster_type))
           return false;
-        if (unitFilter.battalion) {
-          const u = parseUnit(e.position_title || "");
-          if (!u || u.battalion !== unitFilter.battalion) return false;
-          if (unitFilter.company) {
-            const co = u.company ?? "HQ";
-            if (co !== unitFilter.company) return false;
-          }
-          if (unitFilter.platoon && u.platoon !== unitFilter.platoon)
-            return false;
-        }
         return true;
       }),
-    [
-      activeData,
-      activeFilters,
-      excludedRecordTypes,
-      activeRosterTypes,
-      unitFilter,
-    ],
+    [activeData, activeFilters, excludedRecordTypes, activeRosterTypes],
+  );
+
+  const typeFilteredEvents = useMemo(
+    () =>
+      preUnitFilteredEvents.filter((e) => {
+        if (!unitFilter.battalion) return true;
+        const u = parseUnit(e.position_title || "");
+        if (!u || u.battalion !== unitFilter.battalion) return false;
+        if (unitFilter.company) {
+          const co = u.company ?? "HQ";
+          if (co !== unitFilter.company) return false;
+        }
+        if (unitFilter.platoon && u.platoon !== unitFilter.platoon)
+          return false;
+        return true;
+      }),
+    [preUnitFilteredEvents, unitFilter],
   );
 
   const recordTypeCounts = useMemo(() => {
@@ -175,6 +179,11 @@ export function HistoryView() {
 
   const totalVisible =
     notable.length + recordGroups.reduce((n, g) => n + g.records.length, 0);
+
+  // True when an active unit filter is the genuine cause of emptiness:
+  // events survive every other filter, but none match the selected unit.
+  const unitFilterIsCause =
+    Boolean(unitFilter.battalion) && preUnitFilteredEvents.length > 0;
 
   // Aggregate snapshots into heatmap buckets. Bucket size scales with range:
   // ≤90d → daily, ≤365d → weekly, >365d or All → monthly
@@ -380,11 +389,13 @@ export function HistoryView() {
               {heatmapData.map((entry) => {
                 const count = totalCount(entry);
                 const isSelected = entry.date === selectedDay;
+                const cellLabel = `${entry.label}: ${count} change${count !== 1 ? "s" : ""}`;
                 return (
                   <Tooltip key={entry.date}>
                     <TooltipTrigger asChild>
                       <button
                         onClick={() => handleDotClick(entry)}
+                        aria-label={cellLabel}
                         className={cn(
                           "h-4 w-4 rounded-sm transition-transform hover:scale-125 hover:ring-2 hover:ring-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                           heatIntensity(count, maxCount),
@@ -392,9 +403,7 @@ export function HistoryView() {
                         )}
                       />
                     </TooltipTrigger>
-                    <TooltipContent>
-                      {`${entry.label}: ${count} change${count !== 1 ? "s" : ""}`}
-                    </TooltipContent>
+                    <TooltipContent>{cellLabel}</TooltipContent>
                   </Tooltip>
                 );
               })}
@@ -459,12 +468,13 @@ export function HistoryView() {
             presentRosterTypes={presentRosterTypes}
           />
 
-          {!isLoading && (
+          {!isLoading && !isError && (
             <UnitFilterBar
               events={typeFilteredEvents}
               unitFilter={unitFilter}
               onSelect={handleUnitSelect}
               onClear={handleUnitClear}
+              preUnitFilteredCount={preUnitFilteredEvents.length}
             />
           )}
 
@@ -506,12 +516,16 @@ export function HistoryView() {
             <p className="text-muted-foreground text-sm">Loading…</p>
           )}
 
-          {/* When a unit filter matched nothing, UnitFilterBar renders its own
-              explanatory empty state — skip the generic message. */}
+          {/* Skip the generic message only when UnitFilterBar renders its own
+              unit-scoped empty state (unitFilterIsCause). Invariant: this
+              relies on UnitFilterBar receiving the same typeFilteredEvents
+              used to compute totalVisible (plus preUnitFilteredCount for the
+              cause check) — if those ever diverge, restore a fallback
+              message here. */}
           {!isError &&
             !isLoading &&
             totalVisible === 0 &&
-            !unitFilter.battalion && (
+            !unitFilterIsCause && (
               <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
                 <p>
                   No changes{" "}

--- a/client/app/rosterhistory/components/HistoryView.jsx
+++ b/client/app/rosterhistory/components/HistoryView.jsx
@@ -110,7 +110,8 @@ export function HistoryView() {
 
   // Events with every filter EXCEPT the unit predicate applied. Used to
   // decide whether an active unit filter is the actual cause of an empty
-  // view (vs. event-type/roster-type filters having emptied it already).
+  // view (vs. event-type/record-type/roster-type filters having emptied it
+  // already).
   const preUnitFilteredEvents = useMemo(
     () =>
       (activeData?.events ?? []).filter((e) => {
@@ -180,10 +181,13 @@ export function HistoryView() {
   const totalVisible =
     notable.length + recordGroups.reduce((n, g) => n + g.records.length, 0);
 
-  // True when an active unit filter is the genuine cause of emptiness:
-  // events survive every other filter, but none match the selected unit.
+  // True when an active unit filter is the genuine cause of an empty view:
+  // nothing is visible, yet events survive every other filter — so the unit
+  // predicate is what emptied it.
   const unitFilterIsCause =
-    Boolean(unitFilter.battalion) && preUnitFilteredEvents.length > 0;
+    totalVisible === 0 &&
+    Boolean(unitFilter.battalion) &&
+    preUnitFilteredEvents.length > 0;
 
   // Aggregate snapshots into heatmap buckets. Bucket size scales with range:
   // ≤90d → daily, ≤365d → weekly, >365d or All → monthly
@@ -520,8 +524,9 @@ export function HistoryView() {
               unit-scoped empty state (unitFilterIsCause). Invariant: this
               relies on UnitFilterBar receiving the same typeFilteredEvents
               used to compute totalVisible (plus preUnitFilteredCount for the
-              cause check) — if those ever diverge, restore a fallback
-              message here. */}
+              cause check), and on groupAndSortEvents not dropping events
+              (totalVisible === typeFilteredEvents.length) — if either ever
+              diverges, restore a fallback message here. */}
           {!isError &&
             !isLoading &&
             totalVisible === 0 &&

--- a/client/app/rosterhistory/components/TodayView.jsx
+++ b/client/app/rosterhistory/components/TodayView.jsx
@@ -92,7 +92,10 @@ export function TodayView() {
     return s;
   }, [diff]);
 
-  const typeFilteredEvents = useMemo(
+  // Events with every filter EXCEPT the unit predicate applied. Used to
+  // decide whether an active unit filter is the actual cause of an empty
+  // view (vs. event-type/roster-type filters having emptied it already).
+  const preUnitFilteredEvents = useMemo(
     () =>
       (diff?.events ?? []).filter((e) => {
         if (!activeFilters.has(e.event_type)) return false;
@@ -103,19 +106,26 @@ export function TodayView() {
           return false;
         if (e.roster_type && !activeRosterTypes.has(e.roster_type))
           return false;
-        if (unitFilter.battalion) {
-          const u = parseUnit(e.position_title || "");
-          if (!u || u.battalion !== unitFilter.battalion) return false;
-          if (unitFilter.company) {
-            const co = u.company ?? "HQ";
-            if (co !== unitFilter.company) return false;
-          }
-          if (unitFilter.platoon && u.platoon !== unitFilter.platoon)
-            return false;
-        }
         return true;
       }),
-    [diff, activeFilters, excludedRecordTypes, activeRosterTypes, unitFilter],
+    [diff, activeFilters, excludedRecordTypes, activeRosterTypes],
+  );
+
+  const typeFilteredEvents = useMemo(
+    () =>
+      preUnitFilteredEvents.filter((e) => {
+        if (!unitFilter.battalion) return true;
+        const u = parseUnit(e.position_title || "");
+        if (!u || u.battalion !== unitFilter.battalion) return false;
+        if (unitFilter.company) {
+          const co = u.company ?? "HQ";
+          if (co !== unitFilter.company) return false;
+        }
+        if (unitFilter.platoon && u.platoon !== unitFilter.platoon)
+          return false;
+        return true;
+      }),
+    [preUnitFilteredEvents, unitFilter],
   );
 
   const recordTypeCounts = useMemo(() => {
@@ -153,6 +163,11 @@ export function TodayView() {
 
   const totalVisible =
     notable.length + recordGroups.reduce((n, g) => n + g.records.length, 0);
+
+  // True when an active unit filter is the genuine cause of emptiness:
+  // events survive every other filter, but none match the selected unit.
+  const unitFilterIsCause =
+    Boolean(unitFilter.battalion) && preUnitFilteredEvents.length > 0;
 
   function toggleFilter(type) {
     setActiveFilters((prev) => {
@@ -306,12 +321,13 @@ export function TodayView() {
             presentRosterTypes={presentRosterTypes}
           />
 
-          {!diffLoading && (
+          {!diffLoading && !listError && !diffError && (
             <UnitFilterBar
               events={typeFilteredEvents}
               unitFilter={unitFilter}
               onSelect={handleUnitSelect}
               onClear={handleUnitClear}
+              preUnitFilteredCount={preUnitFilteredEvents.length}
             />
           )}
 
@@ -368,18 +384,22 @@ export function TodayView() {
               </div>
             )}
 
-          {/* When a unit filter matched nothing, UnitFilterBar renders its own
-              explanatory empty state — skip the generic messages. */}
+          {/* Skip the generic messages only when UnitFilterBar renders its
+              own unit-scoped empty state (unitFilterIsCause). Invariant: this
+              relies on UnitFilterBar receiving the same typeFilteredEvents
+              used to compute totalVisible (plus preUnitFilteredCount for the
+              cause check) — if those ever diverge, restore a fallback
+              message here. */}
           {diff &&
             totalVisible === 0 &&
             diff.events.length > 0 &&
-            !unitFilter.battalion && (
+            !unitFilterIsCause && (
               <p className="text-muted-foreground text-sm">
                 All event types filtered out.
               </p>
             )}
 
-          {diff?.events?.length === 0 && !unitFilter.battalion && (
+          {diff?.events?.length === 0 && !unitFilterIsCause && (
             <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
               <p>No changes recorded for this date.</p>
             </div>

--- a/client/app/rosterhistory/components/TodayView.jsx
+++ b/client/app/rosterhistory/components/TodayView.jsx
@@ -94,7 +94,8 @@ export function TodayView() {
 
   // Events with every filter EXCEPT the unit predicate applied. Used to
   // decide whether an active unit filter is the actual cause of an empty
-  // view (vs. event-type/roster-type filters having emptied it already).
+  // view (vs. event-type/record-type/roster-type filters having emptied it
+  // already).
   const preUnitFilteredEvents = useMemo(
     () =>
       (diff?.events ?? []).filter((e) => {
@@ -164,10 +165,13 @@ export function TodayView() {
   const totalVisible =
     notable.length + recordGroups.reduce((n, g) => n + g.records.length, 0);
 
-  // True when an active unit filter is the genuine cause of emptiness:
-  // events survive every other filter, but none match the selected unit.
+  // True when an active unit filter is the genuine cause of an empty view:
+  // nothing is visible, yet events survive every other filter — so the unit
+  // predicate is what emptied it.
   const unitFilterIsCause =
-    Boolean(unitFilter.battalion) && preUnitFilteredEvents.length > 0;
+    totalVisible === 0 &&
+    Boolean(unitFilter.battalion) &&
+    preUnitFilteredEvents.length > 0;
 
   function toggleFilter(type) {
     setActiveFilters((prev) => {
@@ -384,12 +388,13 @@ export function TodayView() {
               </div>
             )}
 
-          {/* Skip the generic messages only when UnitFilterBar renders its
-              own unit-scoped empty state (unitFilterIsCause). Invariant: this
+          {/* Skip this message only when UnitFilterBar renders its own
+              unit-scoped empty state (unitFilterIsCause). Invariant: this
               relies on UnitFilterBar receiving the same typeFilteredEvents
               used to compute totalVisible (plus preUnitFilteredCount for the
-              cause check) — if those ever diverge, restore a fallback
-              message here. */}
+              cause check), and on groupAndSortEvents not dropping events
+              (totalVisible === typeFilteredEvents.length) — if either ever
+              diverges, restore a fallback message here. */}
           {diff &&
             totalVisible === 0 &&
             diff.events.length > 0 &&
@@ -399,7 +404,7 @@ export function TodayView() {
               </p>
             )}
 
-          {diff?.events?.length === 0 && !unitFilterIsCause && (
+          {diff?.events?.length === 0 && (
             <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
               <p>No changes recorded for this date.</p>
             </div>

--- a/client/app/rosterhistory/components/TodayView.jsx
+++ b/client/app/rosterhistory/components/TodayView.jsx
@@ -306,12 +306,14 @@ export function TodayView() {
             presentRosterTypes={presentRosterTypes}
           />
 
-          <UnitFilterBar
-            events={typeFilteredEvents}
-            unitFilter={unitFilter}
-            onSelect={handleUnitSelect}
-            onClear={handleUnitClear}
-          />
+          {!diffLoading && (
+            <UnitFilterBar
+              events={typeFilteredEvents}
+              unitFilter={unitFilter}
+              onSelect={handleUnitSelect}
+              onClear={handleUnitClear}
+            />
+          )}
 
           {diff?.counts && (
             <SummaryBar
@@ -366,13 +368,18 @@ export function TodayView() {
               </div>
             )}
 
-          {diff && totalVisible === 0 && diff.events.length > 0 && (
-            <p className="text-muted-foreground text-sm">
-              All event types filtered out.
-            </p>
-          )}
+          {/* When a unit filter matched nothing, UnitFilterBar renders its own
+              explanatory empty state — skip the generic messages. */}
+          {diff &&
+            totalVisible === 0 &&
+            diff.events.length > 0 &&
+            !unitFilter.battalion && (
+              <p className="text-muted-foreground text-sm">
+                All event types filtered out.
+              </p>
+            )}
 
-          {diff?.events?.length === 0 && (
+          {diff?.events?.length === 0 && !unitFilter.battalion && (
             <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
               <p>No changes recorded for this date.</p>
             </div>

--- a/client/app/rosterhistory/components/UnitFilterBar.jsx
+++ b/client/app/rosterhistory/components/UnitFilterBar.jsx
@@ -38,7 +38,13 @@ function UnitChip({ label, active, onClick, onClear }) {
   );
 }
 
-export function UnitFilterBar({ events, unitFilter, onSelect, onClear }) {
+export function UnitFilterBar({
+  events,
+  unitFilter,
+  onSelect,
+  onClear,
+  preUnitFilteredCount,
+}) {
   const unitMap = useMemo(() => {
     const battalions = new Map();
 
@@ -69,9 +75,15 @@ export function UnitFilterBar({ events, unitFilter, onSelect, onClear }) {
   const hasActiveFilter = Boolean(unitFilter.battalion);
 
   if (unitMap.size === 0) {
-    // No units in view. If a unit filter is active it filtered everything
-    // out — explain that instead of silently disappearing.
+    // No units in view. If a unit filter is active, no events in the current
+    // data match it — explain that instead of silently disappearing.
     if (!hasActiveFilter) return null;
+
+    // Only blame the unit filter when it is genuinely the cause: if the
+    // events were already empty before the unit predicate was applied
+    // (e.g. all event types toggled off), the parent's generic message is
+    // the accurate one — render nothing here so it can show.
+    if (preUnitFilteredCount === 0) return null;
 
     const filterLabel = [
       unitFilter.battalion,
@@ -87,10 +99,10 @@ export function UnitFilterBar({ events, unitFilter, onSelect, onClear }) {
         <p className="text-sm">
           No recorded changes for{" "}
           <span className="font-medium text-foreground">{filterLabel}</span> in
-          the current selection.
+          the current view.
         </p>
         <p className="text-xs mt-1 text-muted-foreground/70">
-          Units only appear here when they have recorded changes.
+          Only units with recorded changes in the current view are listed.
         </p>
         <Button
           variant="outline"

--- a/client/app/rosterhistory/components/UnitFilterBar.jsx
+++ b/client/app/rosterhistory/components/UnitFilterBar.jsx
@@ -66,7 +66,44 @@ export function UnitFilterBar({ events, unitFilter, onSelect, onClear }) {
     return battalions;
   }, [events]);
 
-  if (unitMap.size === 0) return null;
+  const hasActiveFilter = Boolean(unitFilter.battalion);
+
+  if (unitMap.size === 0) {
+    // No units in view. If a unit filter is active it filtered everything
+    // out — explain that instead of silently disappearing.
+    if (!hasActiveFilter) return null;
+
+    const filterLabel = [
+      unitFilter.battalion,
+      unitFilter.company &&
+        (unitFilter.company === "HQ" ? "HQ" : `Co. ${unitFilter.company}`),
+      unitFilter.platoon && `Plt. ${unitFilter.platoon}`,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
+    return (
+      <div className="rounded-lg border border-dashed border-border p-6 text-center text-muted-foreground">
+        <p className="text-sm">
+          No recorded changes for{" "}
+          <span className="font-medium text-foreground">{filterLabel}</span> in
+          the current selection.
+        </p>
+        <p className="text-xs mt-1 text-muted-foreground/70">
+          Units only appear here when they have recorded changes.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={() => onClear("battalion")}
+        >
+          <X size={12} />
+          Clear unit filter
+        </Button>
+      </div>
+    );
+  }
 
   const sortedBattalions = [...unitMap.keys()].sort((a, b) => {
     const ai = LINE_BATTALION_ORDER.indexOf(a);
@@ -165,6 +202,10 @@ export function UnitFilterBar({ events, unitFilter, onSelect, onClear }) {
           </div>
         </>
       )}
+
+      <p className="text-[11px] text-muted-foreground/60">
+        Only units with recorded changes in the current view are listed.
+      </p>
     </div>
   );
 }

--- a/client/components/ui/tooltip.jsx
+++ b/client/components/ui/tooltip.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef(
+  ({ className, sideOffset = 4, ...props }, ref) => (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  ),
+);
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.28.0",
         "apexcharts": "^3.54.1",
         "class-variance-authority": "^0.7.1",
@@ -559,6 +560,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
@@ -711,6 +736,58 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -2691,6 +2768,15 @@
         "@radix-ui/react-use-layout-effect": "1.1.1"
       }
     },
+    "@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      }
+    },
     "@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
@@ -2771,6 +2857,35 @@
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
       "requires": {
         "@radix-ui/react-compose-refs": "1.1.2"
+      }
+    },
+    "@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "dependencies": {
+        "@radix-ui/react-slot": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.2"
+          }
+        }
       }
     },
     "@radix-ui/react-use-callback-ref": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.28.0",
     "apexcharts": "^3.54.1",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Closes #136
Closes #137

## What

Two triaged rosterhistory issues implemented via supervised agent swarm, plus two review passes.

### #137 — Heatmap tooltips slow to appear (`a04af5e`)
Native `title` attributes carry an unconfigurable ~1s browser hover delay. Replaced with the shadcn Tooltip primitive (new `client/components/ui/tooltip.jsx`, new dep `@radix-ui/react-tooltip@^1.2.8`) at `delayDuration={100}`, one shared `TooltipProvider` for all ~365 heatmap cells. Tooltip copy unchanged; keyboard focus now also reveals it; `aria-label` preserves the accessible name.

### #136 — Explain why a unit isn't visible (`d84504d`)
`UnitFilterBar` derives chips only from events in view, so units without recorded changes vanished silently and were read as a bug. Now: helper text states the rule, and an active unit filter matching zero events renders the existing dashed-border empty-state pattern naming the unit, with a "Clear unit filter" button. Consistent across Today and History tabs.

### Review fixes (`173690b`, `2e12b31`)
Two multi-agent review passes (code-reviewer + comment-analyzer) over the diff:
- Gate `UnitFilterBar` on error states so failed fetches don't show a false "no recorded changes" message
- Only blame the unit filter when it's genuinely the cause (`preUnitFilteredEvents` split + `unitFilterIsCause`, with `totalVisible === 0` folded into the flag)
- Restore heatmap cell accessible names lost in the tooltip migration
- Copy unification, dead-guard removal, invariant comments naming the suppression contract

## Verification

- Root `npm run format:check` — pass
- `client npx next build` — compiles clean, `/rosterhistory` prerenders; only pre-existing baseline export failures on `/adr` + `/rosterstatistics` (env-var fetches, identical on main)
- Repo has no test runner; CI gate is prettier (`lint_format.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
