### PR TITLE
Serve GET / and /cache-timestamp without a token so healthchecks pass

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -37,10 +37,6 @@ const checkToken = (req, res, next) => {
     return next();
   }
 
-  if (req.method === "OPTIONS") {
-    return next();
-  }
-
   const authToken = req.headers["authorization"];
   if (authToken === CLIENT_TOKEN) {
     next();
@@ -69,11 +65,11 @@ app.use(
     origin: corsOptions.origin,
   }),
 );
-// Apply token checking middleware only to these routes
-app.use("/roster", checkToken, middleware);
-// All diff routes (read views + operator /admin endpoints) sit behind the same
-// token check as /roster; the client sends NEXT_PUBLIC_CLIENT_TOKEN.
-app.use(checkToken, diffRoutes);
+// Public, unauthenticated endpoints. These must be registered before the
+// token gate below — the container healthcheck (curl http://localhost:4000)
+// and the client's readiness probe (wget --spider http://server:4000) both
+// hit GET / with no auth header, so it has to answer 200 without the token.
+// /cache-timestamp is likewise public, as it was before the diff routes landed.
 app.get("/", (req, res) => {
   res.send(
     "Server Test Page Loaded Successfully. Any issues? Submit a ticket to S6! Frontend is at https://apps.7cav.us/",
@@ -83,6 +79,12 @@ app.get("/", (req, res) => {
 app.get("/cache-timestamp", (req, res) => {
   res.json({ cacheTime });
 });
+
+// Apply token checking middleware only to these routes
+app.use("/roster", checkToken, middleware);
+// All diff routes (read views + operator /admin endpoints) sit behind the same
+// token check as /roster; the client sends NEXT_PUBLIC_CLIENT_TOKEN.
+app.use(checkToken, diffRoutes);
 
 // Terminal error handler — backstop for anything a route's own try/catch misses
 // (incl. sync throws and the CORS origin rejection). Without this, an uncaught


### PR DESCRIPTION
## What

`GET /` and `/cache-timestamp` now respond 200 without the client token, so the container healthcheck and the client readiness probe pass again. The diff and admin routes stay behind the token.

## Why

`app.use(checkToken, diffRoutes)` was mounted with no path prefix, so the token check ran for every request. It was registered before the public `GET /` and `/cache-timestamp` handlers, and Express matches middleware in registration order, so a tokenless `GET /` hit the gate and returned 403 before reaching the test-page handler.

That broke the healthcheck (`curl -f http://localhost:4000`) and the client readiness loop (`wget --spider http://server:4000`), both of which send no auth header. The server container stayed unhealthy, the client `depends_on` gate never released, and the stack never came up from a clean source build.

## How

- Register `GET /` and `/cache-timestamp` before the global token gate so they resolve first
- Leave `/roster`, `/diffs`, and `/admin` behind the token
- Remove a duplicated OPTIONS short-circuit in `checkToken`

## Testing

Replicated the exact middleware order from `server.js` in a standalone Express app and hit it with real HTTP requests:

- `GET /` (no token) -> 200
- `GET /cache-timestamp` (no token) -> 200
- `GET /diffs` (no token) -> 403, (token) -> 200
- `GET /roster/combat` (no token) -> 403, (token) -> 200
- `GET /admin/runs` (no token) -> 403

Fixes #151

> *This was generated by AI*