### PR TITLE
Update the example compose so the stack boots locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 #
 # Formatting: use KEY=value with NO spaces around `=` and no surrounding quotes.
 # A stray space (e.g. `API_TOKEN =abc`) makes the variable name `API_TOKEN ` and
-# Docker Compose treats API_TOKEN as unset — the server then 401s on every call.
+# Docker Compose treats API_TOKEN as unset, so the server fails to load the
+# roster on startup and crash-loops instead of coming up.
 
 # ── Required ──────────────────────────────────────────────────────────────────
 
@@ -27,9 +28,11 @@ PG_PASSWORD=cavapps
 # DIFF_POLL_SCHEDULE=*/15 * * * *
 
 # ── XenForo forum database (optional) ─────────────────────────────────────────
-# Only the roster-history diff viewer and user search read from the live XenForo
-# (forum) MariaDB. Leave these blank for local dev — the core roster works
-# without them. Fill them in only if you have a reachable XenForo database.
+# Only the roster-history diff viewer and member search read from the live
+# XenForo (forum) MariaDB. Leave these blank for local dev. The core roster
+# works without them. The diff viewer stays empty; the member-search box returns
+# an error rather than results (its index is never built). Fill them in only if
+# you have a reachable XenForo database.
 # XENFORO_DB_HOST=
 # XENFORO_DB_PORT=3306
 # XENFORO_DB_USER=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# Copy this file to `.env` and fill in the values, then start the stack with:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# Formatting: use KEY=value with NO spaces around `=` and no surrounding quotes.
+# A stray space (e.g. `API_TOKEN =abc`) makes the variable name `API_TOKEN ` and
+# Docker Compose treats API_TOKEN as unset — the server then 401s on every call.
+
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# Authenticates the server to api.7cav.us. A real 7th Cavalry API bearer token.
+# Get it from your 7cav.us account → Connected Accounts → auth.7cav.us (Keycloak).
+# The server fetches the roster on startup and exits if this is missing/invalid.
+API_TOKEN=your-7cav-api-token-here
+
+# Shared secret between the client and server. Any string you choose — it just
+# has to be identical on both sides (it's set once here and reused for both).
+CLIENT_TOKEN=any-shared-secret-you-choose
+
+# ── Local Postgres (optional to set) ──────────────────────────────────────────
+# Backs the roster-history diff store and the user-search cache. This is a
+# throwaway local database created by the `postgres` service in the compose
+# file; the default password below is fine for local development.
+PG_PASSWORD=cavapps
+
+# How often the background poller snapshots the roster (cron syntax). The default
+# (every 15 minutes) is fine; lower it only if you're working on the diff engine.
+# DIFF_POLL_SCHEDULE=*/15 * * * *
+
+# ── XenForo forum database (optional) ─────────────────────────────────────────
+# Only the roster-history diff viewer and user search read from the live XenForo
+# (forum) MariaDB. Leave these blank for local dev — the core roster works
+# without them. Fill them in only if you have a reachable XenForo database.
+# XENFORO_DB_HOST=
+# XENFORO_DB_PORT=3306
+# XENFORO_DB_USER=
+# XENFORO_DB_PASSWORD=
+# XENFORO_DB_NAME=xenforo
+
+# ── Client API URLs (optional to override) ────────────────────────────────────
+# These default to localhost:4000 for local dev (see docker-compose.yml). Set
+# them only if the server is reachable somewhere other than localhost:4000.
+# NEXT_PUBLIC_DIFF_API_URL=http://localhost:4000
+# NEXT_PUBLIC_USERCACHE_API_URL=http://localhost:4000/userSearch
+# NEXT_PUBLIC_INDIVIDUAL_API_URL=http://localhost:4000/roster/individual

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ The live deployment can be found at https://apps.7cav.us/ and the backend at htt
 
 CavApps is a monorepo with two parts:
 
-- **`server/`** — an Express caching proxy ("BFF") that fetches roster data from the 7th Cavalry API and serves it from memory.
+- **`server/`** — an Express caching proxy ("BFF") that fetches roster data from the 7th Cavalry API and serves it from memory. It also keeps a Postgres database for roster-history diffs and the user-search cache.
 - **`client/`** — a Next.js 13 (App Router) app with three tools: the Active Duty Roster (ADR), Roster Statistics, and the Uniform Builder.
 
-The client never talks to the 7th Cavalry API directly — it only talks to the server.
+The client never talks to the 7th Cavalry API directly — it only talks to the server. The Docker setup below brings the Postgres database up for you, so there's nothing extra to install.
 
 ### Authorization
 
@@ -56,12 +56,13 @@ To get your `API_TOKEN`:
 This is the fastest way to get a working dev environment — it builds and runs both the server and client for you, with hot-reload on the client.
 
 1. Install [Docker](https://docs.docker.com/get-docker/) (Docker Desktop on macOS/Windows).
-2. In the project root, create a `.env` file:
+2. In the project root, copy the example env file and fill in your tokens:
 
-   ```dotenv
-   API_TOKEN=your-7cav-api-token-here
-   CLIENT_TOKEN=any-shared-secret-you-choose
+   ```bash
+   cp .env.example .env
    ```
+
+   At a minimum set `API_TOKEN` and `CLIENT_TOKEN`. Everything else has a sensible local default — the Postgres database is created for you, and the XenForo settings can stay blank (see the notes in `.env.example`).
 
 3. Bring the stack up:
 
@@ -75,6 +76,8 @@ That's it. The override file (`docker-compose.dev.yml`) provisions the `edge` ne
 - Server (BFF): http://localhost:4000
 
 The server must successfully load roster data on startup or it will exit and restart — if it keeps restarting, double-check your `API_TOKEN` (see the formatting note above).
+
+> **Two features need the forum database.** The roster-history diff viewer and the member search box read from the live XenForo (forum) MariaDB, which you won't have locally. They simply stay empty — the rest of the app works fine. To enable them, set the `XENFORO_DB_*` values in your `.env` to a reachable XenForo database.
 
 Stop the stack with `Ctrl+C`, or from another terminal:
 
@@ -94,17 +97,26 @@ If you'd rather run the apps directly on your machine instead of in Docker:
 
 ### Manual Setup (without Docker)
 
-You'll run the server and client in two separate terminals.
+You'll run the server and client in two separate terminals. The server also needs a Postgres database — if you don't already have one, the easiest path is to run just that container from the compose file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up postgres
+```
+
+That gives you a database reachable at `postgres://cavapps:cavapps@localhost:5432/cavapps`. (The Docker Quick Start above avoids all of this — only use manual setup if you specifically need the apps running outside Docker.)
 
 **1. Server** (`server/`):
 
 ```bash
 cd server
 npm install
-API_TOKEN=your-7cav-api-token CLIENT_TOKEN=any-shared-secret node server.js
+API_TOKEN=your-7cav-api-token \
+CLIENT_TOKEN=any-shared-secret \
+DATABASE_URL=postgres://cavapps:cavapps@localhost:5432/cavapps?sslmode=disable \
+node server.js
 ```
 
-The server listens on `http://localhost:4000`. Visiting it in a browser confirms it's up. (It reads `API_TOKEN` and `CLIENT_TOKEN` from the environment — export them in your shell or use a tool like [`dotenv`](https://www.npmjs.com/package/dotenv) / a `.env` loader of your choice.)
+The server listens on `http://localhost:4000`. Visiting it in a browser confirms it's up. It reads these values from the environment — export them in your shell or use a tool like [`dotenv`](https://www.npmjs.com/package/dotenv) / a `.env` loader of your choice. It runs its database migrations on startup and exits if `DATABASE_URL` isn't reachable.
 
 **2. Client** (`client/`):
 
@@ -278,14 +290,13 @@ In `CavApps-Test/client/`:
 npm install
 ```
 
-Next, create a `.env` file in the project root with your tokens (see [Authorization](#authorization)):
+Next, create a `.env` file in the project root from the template and fill in your tokens (see [Authorization](#authorization)):
 
-```dotenv
-API_TOKEN=your-7cav-api-token-here
-CLIENT_TOKEN=any-shared-secret-you-choose
+```bash
+cp .env.example .env
 ```
 
-The production `docker-compose.yml` wires the client to reach the server over the internal Docker network (`http://server:4000/...`), so you do **not** need to set the per-URL client variables by hand for a Docker deployment — they're defined in the compose file.
+The `docker-compose.yml` wires the client to reach the server over the internal Docker network (`http://server:4000/...`), so you do **not** need to set the per-URL client variables by hand for a Docker deployment — they're defined in the compose file. It also brings up the Postgres database the server depends on.
 
 Then, from the project root:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To get your `API_TOKEN`:
 2. Open your [Connected Accounts](https://7cav.us/account/connected-accounts/) and click "view account" for `auth.7cav.us`.
 3. Log into Keycloak and copy the provided API token.
 
-> **Heads up on `.env` formatting:** use `KEY=value` with **no spaces around the `=`** and no surrounding quotes. A line like `API_TOKEN ='abc'` (note the space) makes the variable name `API_TOKEN ` (with a trailing space), so Docker Compose treats `API_TOKEN` as unset and the server fails to start with a `401 Unauthorized`.
+> **Heads up on `.env` formatting:** use `KEY=value` with **no spaces around the `=`** and no surrounding quotes. A line like `API_TOKEN ='abc'` (note the space) makes the variable name `API_TOKEN ` (with a trailing space), so Docker Compose treats `API_TOKEN` as unset and the server fails to load the roster on startup, then crash-loops instead of coming up.
 
 ### Quick Start with Docker (recommended)
 
@@ -77,7 +77,7 @@ That's it. The override file (`docker-compose.dev.yml`) provisions the `edge` ne
 
 The server must successfully load roster data on startup or it will exit and restart — if it keeps restarting, double-check your `API_TOKEN` (see the formatting note above).
 
-> **Two features need the forum database.** The roster-history diff viewer and the member search box read from the live XenForo (forum) MariaDB, which you won't have locally. They simply stay empty — the rest of the app works fine. To enable them, set the `XENFORO_DB_*` values in your `.env` to a reachable XenForo database.
+> **Two features need the forum database.** The roster-history diff viewer and the member search box read from the live XenForo (forum) MariaDB, which you won't have locally. The diff viewer just stays empty; the member search returns an error if you use it, since its index is never built. The rest of the app works fine. To enable them, set the `XENFORO_DB_*` values in your `.env` to a reachable XenForo database.
 
 Stop the stack with `Ctrl+C`, or from another terminal:
 
@@ -103,7 +103,7 @@ You'll run the server and client in two separate terminals. The server also need
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up postgres
 ```
 
-That gives you a database reachable at `postgres://cavapps:cavapps@localhost:5432/cavapps`. (The Docker Quick Start above avoids all of this — only use manual setup if you specifically need the apps running outside Docker.)
+That gives you a database reachable at `postgres://cavapps:cavapps@localhost:5432/cavapps`. (This URL and the `DATABASE_URL` below assume the default `PG_PASSWORD=cavapps`; update both if you set your own.) The Docker Quick Start above avoids all of this; only use manual setup if you specifically need the apps running outside Docker.
 
 **1. Server** (`server/`):
 
@@ -129,6 +129,8 @@ RESERVE_API_URL=http://localhost:4000/roster/reserves
 GROUP_API_URL=http://localhost:4000/roster/groups
 CACHE_TIMESTAMP_URL=http://localhost:4000/cache-timestamp
 NEXT_PUBLIC_INDIVIDUAL_API_URL=http://localhost:4000/roster/individual
+NEXT_PUBLIC_DIFF_API_URL=http://localhost:4000
+NEXT_PUBLIC_USERCACHE_API_URL=http://localhost:4000/userSearch
 ```
 
 `NEXT_PUBLIC_CLIENT_TOKEN` **must match** the server's `CLIENT_TOKEN`. Then:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,35 @@
+# CavApps stack — builds the server and client from source so your local changes
+# are what runs. For local development always layer the dev override on top:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# The override provisions the `edge` network locally (in production that network
+# is managed by the reverse proxy). See README "Running Locally".
+#
+# Secrets and per-environment values come from a `.env` file in this directory.
+# Copy `.env.example` to `.env` and fill in your tokens before bringing it up.
 services:
+  # Postgres backs the roster-history diff store and the user-search cache.
+  # The server runs its migrations on startup and will not boot until this is
+  # reachable, so it comes up first as part of the stack — no setup required.
+  postgres:
+    image: postgres:16-alpine
+    container_name: cavapps-postgres
+    restart: always
+    environment:
+      POSTGRES_DB: cavapps
+      POSTGRES_USER: cavapps
+      POSTGRES_PASSWORD: ${PG_PASSWORD:-cavapps}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cavapps -d cavapps"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - cavapps-network
+
   server:
     restart: always
     #image: 7cav/apps_beta_server:latest
@@ -13,7 +44,22 @@ services:
     environment:
       API_TOKEN: ${API_TOKEN}
       CLIENT_TOKEN: ${CLIENT_TOKEN}
+      DATABASE_URL: postgres://cavapps:${PG_PASSWORD:-cavapps}@postgres:5432/cavapps?sslmode=disable
+      DIFF_POLL_SCHEDULE: ${DIFF_POLL_SCHEDULE:-*/15 * * * *}
+      # Optional: the roster-history diff viewer and user search read from the
+      # live XenForo (forum) MariaDB. Leave these blank for local dev — the core
+      # roster works without them; only those two features stay empty (the poller
+      # logs a connection error each tick and moves on). Fill them in if you have
+      # a reachable XenForo database (e.g. an SSH tunnel or a read replica).
+      XENFORO_DB_HOST: ${XENFORO_DB_HOST:-}
+      XENFORO_DB_PORT: ${XENFORO_DB_PORT:-3306}
+      XENFORO_DB_USER: ${XENFORO_DB_USER:-}
+      XENFORO_DB_PASSWORD: ${XENFORO_DB_PASSWORD:-}
+      XENFORO_DB_NAME: ${XENFORO_DB_NAME:-xenforo}
     working_dir: /server
+    depends_on:
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4000"]
       interval: 10s
@@ -40,11 +86,17 @@ services:
     environment:
       DEVMODE: "true"
       NEXT_PUBLIC_CLIENT_TOKEN: ${CLIENT_TOKEN}
+      # Server-side fetches (Next.js route handlers / server components) reach the
+      # server over the internal Docker network.
       COMBAT_API_URL: http://server:4000/roster/combat
       RESERVE_API_URL: http://server:4000/roster/reserves
       CACHE_TIMESTAMP_URL: http://server:4000/cache-timestamp
       GROUP_API_URL: http://server:4000/roster/groups
-      NEXT_PUBLIC_INDIVIDUAL_API_URL: http://localhost:4000/roster/individual
+      # NEXT_PUBLIC_* values are baked into the browser bundle, so they must point
+      # at a URL the browser can reach (localhost), not the internal `server` host.
+      NEXT_PUBLIC_DIFF_API_URL: ${NEXT_PUBLIC_DIFF_API_URL:-http://localhost:4000}
+      NEXT_PUBLIC_USERCACHE_API_URL: ${NEXT_PUBLIC_USERCACHE_API_URL:-http://localhost:4000/userSearch}
+      NEXT_PUBLIC_INDIVIDUAL_API_URL: ${NEXT_PUBLIC_INDIVIDUAL_API_URL:-http://localhost:4000/roster/individual}
     working_dir: /client
     ports:
       - "3000:3000"
@@ -76,3 +128,6 @@ networks:
     name: edge
   cavapps-network:
     driver: bridge
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 # CavApps stack — builds the server and client from source so your local changes
-# are what runs. For local development always layer the dev override on top:
+# are what runs. The client is bind-mounted and hot-reloads; the server is baked
+# into its image at build time, so server changes need a rebuild (--build), not
+# just a restart. For local development always layer the dev override on top:
 #
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 #
@@ -46,11 +48,13 @@ services:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       DATABASE_URL: postgres://cavapps:${PG_PASSWORD:-cavapps}@postgres:5432/cavapps?sslmode=disable
       DIFF_POLL_SCHEDULE: ${DIFF_POLL_SCHEDULE:-*/15 * * * *}
-      # Optional: the roster-history diff viewer and user search read from the
-      # live XenForo (forum) MariaDB. Leave these blank for local dev — the core
-      # roster works without them; only those two features stay empty (the poller
-      # logs a connection error each tick and moves on). Fill them in if you have
-      # a reachable XenForo database (e.g. an SSH tunnel or a read replica).
+      # Optional: the roster-history diff viewer and member search read from the
+      # live XenForo (forum) MariaDB. Leave these blank for local dev; the core
+      # roster works without them. Without XenForo the diff poller just logs a
+      # connection error each tick and moves on (the diff viewer stays empty),
+      # and the user-search index is never built, so the member-search box
+      # returns an error rather than results. Fill them in if you have a
+      # reachable XenForo database (e.g. an SSH tunnel or a read replica).
       XENFORO_DB_HOST: ${XENFORO_DB_HOST:-}
       XENFORO_DB_PORT: ${XENFORO_DB_PORT:-3306}
       XENFORO_DB_USER: ${XENFORO_DB_USER:-}


### PR DESCRIPTION
## What

The example `docker-compose.yml` had fallen behind production and could no longer start the stack from a fresh clone. The server now needs Postgres at boot: it runs its migrations in `initDatabase()` and exits if the database isn't reachable. The example compose had no database service, so it never got past startup.

This brings the example back in line with the live prod compose (sanitized) so a contributor can bring the whole stack up locally.

## Changes

- Add a `postgres` service with a healthcheck and a `pgdata` volume, point the server's `DATABASE_URL` at it, and make the server wait for the database to be healthy.
- Add the server's `DIFF_POLL_SCHEDULE` and `XENFORO_DB_*` settings. The XenForo (forum) database is optional: only the roster-history diff viewer and member search read from it, and they stay empty locally without it. The core roster works fine.
- Add the two client URLs that were missing (`NEXT_PUBLIC_DIFF_API_URL`, `NEXT_PUBLIC_USERCACHE_API_URL`).
- Add a `.env.example` that documents every variable and marks what's required. Only `API_TOKEN` and `CLIENT_TOKEN` are mandatory; everything else has a local default.
- Update the README so the quick start copies `.env.example`, and so the manual (non-Docker) setup sets `DATABASE_URL` (otherwise the server crashes at startup).

## Sanitization

No secrets are committed. Every value comes from `.env` (gitignored); `.env.example` holds only placeholders and local-throwaway defaults. Prod-only pieces are dropped: prebuilt images, watchtower labels, and the external `xenforo_internal` network.

## How I tested it

`docker compose config` validates for both the local-dev path (`-f docker-compose.yml -f docker-compose.dev.yml`) and the base path. The local path resolves cleanly; the base path only warns about the two unset secrets, which is expected.

> *This was generated by AI*