### PR TITLE
Hotfix for badges

### DIFF
--- a/client/app/uniformbuilder/modules/AwardClasses.jsx
+++ b/client/app/uniformbuilder/modules/AwardClasses.jsx
@@ -237,35 +237,41 @@ export class BadgeCombat extends Badge {
     this.maxAllowed = 5;
   }
 
-  getImageNum(num) {
-    // in the images folder, the numbers are defined as follows:
-    // 1 - 5 EIB thru CIB4
-    // 6 FMB
-    // 7 - 9 aviator wings
-    // 10 - 12 aircrew wings
+  getImageNum(awardPriority) {
+    // badges are defined as images in app/public/skunkworks/uniformBadges/combatBadges
+    // e.g. flight medic badge is named 6.png
+    const Badges = Object.freeze({
+      flightMedicBadge: 6,
+      aviator: 7,
+      seniorAviator: 8,
+      masterAviator: 9,
+      aircrew: 10,
+      seniorAircrew: 11,
+      masterAircrew: 12,
+    });
 
     if (this.isAviation) {
-      switch (num) {
+      switch (awardPriority) {
         case 6:
-          return 10;
+          return Badges.aircrew;
         case 7:
-          return 11;
+          return Badges.seniorAircrew;
         case 8:
-          return 12;
+          return Badges.masterAircrew;
         case 9:
-          return 7;
+          return Badges.aviator;
         case 10:
-          return 8;
+          return Badges.seniorAviator;
         case 11:
-          return 9;
+          return Badges.masterAviator;
       }
     }
 
-    if (this.isMedical && num == 6) {
-      return 6;
+    if (this.isMedical && awardPriority == 6) {
+      return Badges.flightMedicBadge;
     }
 
-    return num;
+    return awardPriority;
   }
 
   updateBadgeCombat(newAwardData, AwardRegistry) {

--- a/client/app/uniformbuilder/modules/AwardClasses.jsx
+++ b/client/app/uniformbuilder/modules/AwardClasses.jsx
@@ -223,8 +223,7 @@ export class BadgeCombat extends Badge {
       return;
     }
 
-    //we need to give 15T an exception so that they stop at aircrew badges.
-
+    //we need to give 15T (aircrew) an exception so that they stop at aircrew badges.
     if (this.isAviation) {
       if (MosGroup.AIRCREW.includes(this.userMos)) {
         this.maxAllowed = 8;
@@ -238,9 +237,10 @@ export class BadgeCombat extends Badge {
   }
 
   getImageNum(awardPriority) {
-    // badges are defined as images in app/public/skunkworks/uniformBadges/combatBadges
-    // e.g. flight medic badge is named 6.png
-    const Badges = Object.freeze({
+    // Maps awardPriority from constants/awardCatalog.js to a badge image that
+    // canvas.jsx will use to render from client/public/skunkworks/uniformBadges/combatBadges/<n>.png
+    // awardPriority values 1-5 (EIB thru CIB4) are universal and are matched by default and fall through.
+    const BadgeImage = Object.freeze({
       flightMedicBadge: 6,
       aviator: 7,
       seniorAviator: 8,
@@ -253,22 +253,24 @@ export class BadgeCombat extends Badge {
     if (this.isAviation) {
       switch (awardPriority) {
         case 6:
-          return Badges.aircrew;
+          return BadgeImage.aircrew;
         case 7:
-          return Badges.seniorAircrew;
+          return BadgeImage.seniorAircrew;
         case 8:
-          return Badges.masterAircrew;
+          return BadgeImage.masterAircrew;
         case 9:
-          return Badges.aviator;
+          return BadgeImage.aviator;
         case 10:
-          return Badges.seniorAviator;
+          return BadgeImage.seniorAviator;
         case 11:
-          return Badges.masterAviator;
+          return BadgeImage.masterAviator;
       }
     }
 
+    // awardPriority 6 is used for both aviation and medical trees.
+    // isMedical will claim the value for the medical tree.
     if (this.isMedical && awardPriority == 6) {
-      return Badges.flightMedicBadge;
+      return BadgeImage.flightMedicBadge;
     }
 
     return awardPriority;

--- a/client/app/uniformbuilder/modules/constants/awardCatalog.js
+++ b/client/app/uniformbuilder/modules/constants/awardCatalog.js
@@ -429,17 +429,17 @@ export const AWARD_CATALOG = [
   }, // (3/1/b/1-7) (4/1/b/1-7)
   {
     name: "Master Army Aviator Badge",
-    awardPriority: 8,
+    awardPriority: 11,
     awardType: AwardType.BadgeCombat,
   }, // (A/1-7) (A/ACD)
   {
     name: "Senior Army Aviator Badge",
-    awardPriority: 7,
+    awardPriority: 10,
     awardType: AwardType.BadgeCombat,
   },
   {
     name: "Army Aviator Badge",
-    awardPriority: 6,
+    awardPriority: 9,
     awardType: AwardType.BadgeCombat,
   },
   {
@@ -463,13 +463,13 @@ export const AWARD_CATALOG = [
     awardType: AwardType.BadgeCombat,
   },
   {
-    name: "Combat Infantry Badge 2nd Award",
-    awardPriority: 3,
+    name: "Combat Infantry Badge 3rd Award",
+    awardPriority: 4,
     awardType: AwardType.BadgeCombat,
   },
   {
-    name: "Combat Infantry Badge 3rd Award",
-    awardPriority: 4,
+    name: "Combat Infantry Badge 2nd Award",
+    awardPriority: 3,
     awardType: AwardType.BadgeCombat,
   },
   {


### PR DESCRIPTION
addresses an issue in the recent refactor in which the badge logic changes did not carry over.

additionally includes a rewrite so that the logic behind combat badge selection is easier to understand.