### PR TITLE
fix(uniformbuilder): repair the award sprite generator broken by #130

### DIFF
--- a/.github/workflows/award_sprites.yml
+++ b/.github/workflows/award_sprites.yml
@@ -80,7 +80,7 @@ jobs:
 
             This PR contains only the regenerated sprite-sheet PNG(s) and the
             upload-folder cleanup (consumed source art removed, manifest
-            emptied). Placement was read from `AwardRegistry.jsx`.
+            emptied). Placement was read from `constants/awardCatalog.js`.
 
             **Generator warnings** (e.g. a medal placed with a transparent gap,
             or a ribbon stretched from a wrong-sized source):

--- a/client/app/uniformbuilder/modules/constants/awardCatalog.js
+++ b/client/app/uniformbuilder/modules/constants/awardCatalog.js
@@ -1,5 +1,8 @@
-import { AwardType } from "./awardTypes";
-import { AwardAttachmentType } from "./awardAttachmentTypes";
+// Extensions are explicit so this module resolves under plain Node as well as
+// the Next bundler: generateAwardSprites.js imports it directly to read award
+// placement, and Node's ESM resolver does not guess extensions.
+import { AwardType } from "./awardTypes.js";
+import { AwardAttachmentType } from "./awardAttachmentTypes.js";
 
 // The full award catalog: name + per-award metadata. AwardRegistry loops this
 // in order to populate its Map, so KEEP THE ORDER STABLE — Map iteration order

--- a/generateAwardSprites.js
+++ b/generateAwardSprites.js
@@ -7,11 +7,11 @@
  * `constants/awardCatalog.js` (the human-owned source of truth for placement,
  * imported as a module — see loadCatalog), normalizes each source PNG to its
  * target tile geometry, and splices the tile into the correct sprite sheet(s)
- * at the catalog-derived row. An
- * in-bounds insert shifts every lower row down by its tile height (N inserts
- * shift the bottom band down by N tiles); an insert past the current end pads
- * the sub-tile remainder with transparency and appends without shifting
- * anything. An entry flagged `replace: true` overwrites the tile already at
+ * at the catalog-derived row. An in-bounds insert shifts every lower row down
+ * by its tile height (N inserts shift the bottom band down by N tiles); an
+ * insert past the current end pads the sub-tile remainder with transparency
+ * and appends without shifting anything. An entry flagged `replace: true`
+ * overwrites the tile already at
  * that row in place — no shift, no growth — to fix the art of an award that
  * already has a tile. Consumed sources and their manifest entries are then
  * removed.
@@ -27,9 +27,11 @@
  * Run via `npm run sprites:generate` to process the real manifest, or require
  * it as a module to use the exported helpers in tests. Prefer the npm script
  * over a bare `node generateAwardSprites.js`: it carries the flag that mutes
- * Node's MODULE_TYPELESS_PACKAGE_JSON notice for the imported catalog, which
- * is ESM under a package.json that cannot be marked `"type": "module"`
- * (client/next.config.js is CommonJS and would break).
+ * Node's MODULE_TYPELESS_PACKAGE_JSON notice for the imported catalog. That
+ * notice points at `client/package.json`, and marking THAT `"type": "module"`
+ * would require converting `client/next.config.js`, which is CommonJS. Do not
+ * add `"type"` to the root package.json instead — it would break this
+ * generator and silence nothing.
  */
 
 const fs = require("fs");
@@ -97,13 +99,29 @@ function onMedalSheet(award) {
  *
  * Throws on a malformed catalog rather than returning a partial index: a
  * nameless entry or a duplicate name means the app's own AwardRegistry Map is
- * broken too (it keys on the same field and a duplicate silently wins), so
- * failing here surfaces it instead of quietly misplacing a tile.
+ * broken too (it keys on the same field, so the LAST duplicate silently wins
+ * and the earlier one vanishes), so failing here surfaces it instead of
+ * quietly misplacing a tile.
+ *
+ * An empty array is rejected for a sharper reason. AWARD_CATALOG is a
+ * hand-maintained file of ~100 awards, so zero entries never means "no awards
+ * yet" — it means the module resolved but the data did not come with it.
+ * Without this, every manifest entry fails as "not present in the award
+ * catalog", which is the same misdirection that hid the original breakage: it
+ * sends the operator off to re-check the spelling of an award they just added.
  */
 function indexCatalog(entries) {
   if (!Array.isArray(entries)) {
     throw new Error(
       `award catalog must export AWARD_CATALOG as an array, got ${typeof entries}`,
+    );
+  }
+  if (entries.length === 0) {
+    throw new Error(
+      "award catalog exported AWARD_CATALOG as an EMPTY array; the module " +
+        "resolved but carried no awards, so the generator is not reading the " +
+        "data you edited. Check that AWARD_CATALOG is still the exported name " +
+        "and that the array literal is intact.",
     );
   }
   const byName = new Map();
@@ -126,9 +144,11 @@ function indexCatalog(entries) {
  *
  * The catalog is imported, not parsed as text: it is the same module the
  * uniform builder renders from, so the generator and the app can never
- * disagree about where an award sits. That coupling is the point — a refactor
- * that moves or renames this data now breaks the import loudly instead of
- * leaving a text matcher quietly finding nothing.
+ * disagree about which row an award sits in. (They can still disagree about
+ * NAMES — the app resolves through AwardRegistry.getAwardDetails, which strips
+ * valor devices first, while lookupAward here is exact-match.) That coupling
+ * is the point — a refactor that moves or renames this data now breaks the
+ * import loudly instead of leaving a text matcher quietly finding nothing.
  *
  * Imported by file URL so absolute Windows paths resolve; `await import` of an
  * ES module is why every caller of this is async.
@@ -160,12 +180,17 @@ const FIELD_IS_USABLE = {
  * sheet — its tile never placed, reported only as the misleading "does not
  * belong to this sheet".
  *
- * Keyed on whether the field is WRITTEN, not on `!== undefined`. An entry that
- * spells out `medalPriority: undefined` — which is what a typo'd or deleted
- * enum reference evaluates to — has declared an intent to sit on the medal
- * sheet and must be rejected, whereas an entry that simply omits the key is a
- * legitimate ribbon-only award. Collapsing those two would splice the ribbon
- * tile, skip the medal tile, and still exit 0.
+ * Keyed on whether the field is WRITTEN, not on `!== undefined`, because the
+ * two mean opposite things here. An entry that omits `medalPriority` is a
+ * legitimate ribbon-only award. An entry that spells the key out and lands on
+ * `undefined` — a mistyped `AwardType.Medl`, a constant deleted out from under
+ * it, a spread of a half-built object — has declared an intent to sit on the
+ * medal sheet and must be rejected. Collapsing those two would splice the
+ * ribbon tile, skip the medal tile, and still exit 0.
+ *
+ * Note this cannot catch a MISSPELLED key (`medalPriorty: 5`), which reads as
+ * omitted. Neither could the text matcher this replaced. See the manifest-side
+ * checks in validateManifest for the other half of that problem.
  */
 function malformedFields(award) {
   return Object.keys(FIELD_IS_USABLE).filter(
@@ -262,7 +287,7 @@ async function normalizeMedal(srcPath) {
  * Splice tiles into a sheet by raw-byte concatenation — the only operation
  * that guarantees every non-inserted row stays byte-identical and the sheet's
  * trailing sub-tile pixels survive. Inserts are applied in ascending row
- * order, each at its registry-derived `y`, on the progressively grown sheet
+ * order, each at its catalog-derived `y`, on the progressively grown sheet
  * (correctly interleaving multiple inserts at their final positions). When a
  * row lands at or beyond the current end — a new bottom-most award, given the
  * sub-tile remainder — the sheet is padded with transparency up to `y` so the
@@ -275,7 +300,7 @@ async function normalizeMedal(srcPath) {
  * target — the copy clamps to the bytes remaining there.
  *
  * Replaces and inserts must NOT be mixed in one call: a replace copies into an
- * absolute byte offset derived from the registry row, but an insert grows the
+ * absolute byte offset derived from the catalog row, but an insert grows the
  * buffer and shifts every lower row down, so a replace sorted after an insert
  * would land on the shifted neighbour instead of its target — overwriting the
  * wrong award while the intended one stays broken, with the run still exiting
@@ -313,8 +338,8 @@ async function buildSplicedSheet(sheetPath, inserts) {
     if (ins.replace) {
       // Overwrite the existing tile at `y` in place — no shift, no growth.
       // Gate on the row's *start*, not its full height: the bottom-most award
-      // sits in the sheet's sub-tile remainder (the real ribbon sheet is 769px
-      // = 54*14 + 13, so its last row is only 13px), and `rawTile.copy` clamps
+      // sits in the sheet's sub-tile remainder (the real ribbon sheet is 783px
+      // = 55*14 + 13, so its last row is only 13px), and `rawTile.copy` clamps
       // to the bytes actually left, writing the partial row without overrun.
       if (ins.y >= height) {
         throw new Error(
@@ -334,7 +359,7 @@ async function buildSplicedSheet(sheetPath, inserts) {
       ]);
     } else {
       // Append past the end: pad the gap (the sub-tile remainder) with
-      // transparency, then place the tile at its exact registry row.
+      // transparency, then place the tile at its exact catalog row.
       const pad = Buffer.alloc((ins.y - height) * width * channels);
       data = Buffer.concat([data, pad, rawTile]);
     }

--- a/generateAwardSprites.js
+++ b/generateAwardSprites.js
@@ -4,9 +4,10 @@
  * Award sprite-sheet generator.
  *
  * Reads `uniform-uploads/manifest.json`, validates every entry against
- * `AwardRegistry.jsx` (the human-owned source of truth for placement),
- * normalizes each source PNG to its target tile geometry, and splices the
- * tile into the correct sprite sheet(s) at the registry-derived row. An
+ * `constants/awardCatalog.js` (the human-owned source of truth for placement,
+ * imported as a module — see loadCatalog), normalizes each source PNG to its
+ * target tile geometry, and splices the tile into the correct sprite sheet(s)
+ * at the catalog-derived row. An
  * in-bounds insert shifts every lower row down by its tile height (N inserts
  * shift the bottom band down by N tiles); an insert past the current end pads
  * the sub-tile remainder with transparency and appends without shifting
@@ -23,12 +24,17 @@
  * in these two sheets (Tabs, weapon quals, unit citations, and badges render
  * from other assets). See RIBBON_SHEET_TYPES / MEDAL_SHEET_TYPES below.
  *
- * Run directly (`node generateAwardSprites.js`) to process the real manifest,
- * or require it as a module to use the exported helpers in tests.
+ * Run via `npm run sprites:generate` to process the real manifest, or require
+ * it as a module to use the exported helpers in tests. Prefer the npm script
+ * over a bare `node generateAwardSprites.js`: it carries the flag that mutes
+ * Node's MODULE_TYPELESS_PACKAGE_JSON notice for the imported catalog, which
+ * is ESM under a package.json that cannot be marked `"type": "module"`
+ * (client/next.config.js is CommonJS and would break).
  */
 
 const fs = require("fs");
 const path = require("path");
+const { pathToFileURL } = require("url");
 const sharp = require("sharp");
 
 const ROOT = __dirname;
@@ -36,9 +42,9 @@ const ROOT = __dirname;
 const DEFAULT_PATHS = {
   uploadDir: path.join(ROOT, "uniform-uploads"),
   manifest: path.join(ROOT, "uniform-uploads", "manifest.json"),
-  registry: path.join(
+  catalog: path.join(
     ROOT,
-    "client/app/uniformbuilder/modules/AwardRegistry.jsx",
+    "client/app/uniformbuilder/modules/constants/awardCatalog.js",
   ),
   ribbonSheet: path.join(
     ROOT,
@@ -67,11 +73,7 @@ const MEDAL_SHEET_TYPES = new Set(["Medal", "MedalTiered", "MedalWithValor"]);
 // priorities 0/1 (the Lifetime medals) are not on it.
 const MEDAL_MIN_PRIORITY = 2;
 
-function escapeRegExp(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/** Does this parsed award have a tile on the ribbon sheet? */
+/** Does this award have a tile on the ribbon sheet? */
 function onRibbonSheet(award) {
   return (
     !!award &&
@@ -80,7 +82,7 @@ function onRibbonSheet(award) {
   );
 }
 
-/** Does this parsed award have a tile on the medal sheet? */
+/** Does this award have a tile on the medal sheet? */
 function onMedalSheet(award) {
   return (
     !!award &&
@@ -90,74 +92,84 @@ function onMedalSheet(award) {
   );
 }
 
-// Field matchers, shared by the parser and the present-but-unparsed check so
-// the two can never drift on what counts as a valid value.
-const FIELD_RE = {
-  awardPriority: /awardPriority\s*:\s*(\d+)/,
-  medalPriority: /medalPriority\s*:\s*(\d+)/,
-  awardType: /awardType\s*:\s*["'`]([A-Za-z]+)["'`]/,
+/**
+ * Index an AWARD_CATALOG array by award name.
+ *
+ * Throws on a malformed catalog rather than returning a partial index: a
+ * nameless entry or a duplicate name means the app's own AwardRegistry Map is
+ * broken too (it keys on the same field and a duplicate silently wins), so
+ * failing here surfaces it instead of quietly misplacing a tile.
+ */
+function indexCatalog(entries) {
+  if (!Array.isArray(entries)) {
+    throw new Error(
+      `award catalog must export AWARD_CATALOG as an array, got ${typeof entries}`,
+    );
+  }
+  const byName = new Map();
+  entries.forEach((entry, i) => {
+    if (!entry || typeof entry.name !== "string" || entry.name === "") {
+      throw new Error(`award catalog entry ${i} has no usable "name"`);
+    }
+    if (byName.has(entry.name)) {
+      throw new Error(
+        `award catalog has a duplicate name "${entry.name}" (entry ${i})`,
+      );
+    }
+    byName.set(entry.name, entry);
+  });
+  return byName;
+}
+
+/**
+ * Import the award catalog and index it by name.
+ *
+ * The catalog is imported, not parsed as text: it is the same module the
+ * uniform builder renders from, so the generator and the app can never
+ * disagree about where an award sits. That coupling is the point — a refactor
+ * that moves or renames this data now breaks the import loudly instead of
+ * leaving a text matcher quietly finding nothing.
+ *
+ * Imported by file URL so absolute Windows paths resolve; `await import` of an
+ * ES module is why every caller of this is async.
+ */
+async function loadCatalog(catalogPath) {
+  const mod = await import(pathToFileURL(catalogPath).href);
+  return indexCatalog(mod.AWARD_CATALOG);
+}
+
+/** Look up one award's details by name, or null when it is not in the catalog. */
+function lookupAward(catalog, name) {
+  return catalog.get(name) ?? null;
+}
+
+// What each placement field must hold to be usable. One table so the check can
+// never drift field-by-field, and so adding a field is one line here.
+const FIELD_IS_USABLE = {
+  awardPriority: (v) => Number.isInteger(v) && v >= 0,
+  medalPriority: (v) => Number.isInteger(v) && v >= 0,
+  awardType: (v) => typeof v === "string" && v !== "",
 };
 
 /**
- * Extract the brace-balanced object-literal body for a single award out of the
- * registry SOURCE TEXT (never executed). Matches `this.awards.set(<"name"
- * |`name`>, { ... })` for the exact literal name and returns the text between
- * the matching braces, or null when the name is absent. Brace-balanced (rather
- * than stopping at the first `}`) so an entry containing a nested object is
- * captured in full instead of being truncated mid-entry.
+ * Names of placement fields the award states but fills with a value the
+ * splicer cannot use as a row index or a sheet-membership key.
+ *
+ * Guards the dangerous case: a field set to something unusable would otherwise
+ * read as "field not set," making the award look like a non-member of that
+ * sheet — its tile never placed, reported only as the misleading "does not
+ * belong to this sheet".
+ *
+ * Keyed on whether the field is WRITTEN, not on `!== undefined`. An entry that
+ * spells out `medalPriority: undefined` — which is what a typo'd or deleted
+ * enum reference evaluates to — has declared an intent to sit on the medal
+ * sheet and must be rejected, whereas an entry that simply omits the key is a
+ * legitimate ribbon-only award. Collapsing those two would splice the ribbon
+ * tile, skip the medal tile, and still exit 0.
  */
-function extractAwardBody(registryText, name) {
-  const escaped = escapeRegExp(name);
-  const head = new RegExp(
-    'this\\.awards\\.set\\(\\s*[`"]' + escaped + '[`"]\\s*,\\s*\\{',
-  );
-  const m = registryText.match(head);
-  if (!m) return null;
-  const start = m.index + m[0].length; // first char after the opening "{"
-  let depth = 1;
-  let i = start;
-  for (; i < registryText.length && depth > 0; i++) {
-    const ch = registryText[i];
-    if (ch === "{") depth++;
-    else if (ch === "}") depth--;
-  }
-  if (depth !== 0) return null; // unbalanced — treat as not found
-  return registryText.slice(start, i - 1);
-}
-
-/**
- * Parse a single award's placement out of the registry source text. Returns
- * null when the name is absent, otherwise an object with whatever of
- * `awardPriority`/`medalPriority`/`awardType` parsed. A field that is present
- * in the registry but fails to parse comes back absent here — callers must run
- * {@link unparsedFields} to reject that case rather than treat it as "field
- * not set," or a placement can be silently dropped.
- */
-function parseAward(registryText, name) {
-  const body = extractAwardBody(registryText, name);
-  if (body === null) return null;
-  const award = {};
-  const ap = body.match(FIELD_RE.awardPriority);
-  const mp = body.match(FIELD_RE.medalPriority);
-  const at = body.match(FIELD_RE.awardType);
-  if (ap) award.awardPriority = Number(ap[1]);
-  if (mp) award.medalPriority = Number(mp[1]);
-  if (at) award.awardType = at[1];
-  return award;
-}
-
-/**
- * Names of fields that appear (as a `key:`) in the award's registry body but
- * whose value did not parse — the dangerous case the parser would otherwise
- * drop silently. Returns [] when the name is absent or every present field
- * parsed cleanly.
- */
-function unparsedFields(registryText, name) {
-  const body = extractAwardBody(registryText, name);
-  if (body === null) return [];
-  return Object.keys(FIELD_RE).filter(
-    (key) =>
-      new RegExp("\\b" + key + "\\s*:").test(body) && !FIELD_RE[key].test(body),
+function malformedFields(award) {
+  return Object.keys(FIELD_IS_USABLE).filter(
+    (key) => Object.hasOwn(award, key) && !FIELD_IS_USABLE[key](award[key]),
   );
 }
 
@@ -348,10 +360,11 @@ async function spliceSheet(sheetPath, inserts) {
 }
 
 /**
- * Validate the manifest against the registry. Returns { errors, warnings }.
- * `errors` non-empty means the run must abort before any image is written.
+ * Validate the manifest against the award catalog (a name-indexed Map from
+ * {@link loadCatalog}). Returns { errors, warnings }; `errors` non-empty means
+ * the run must abort before any image is written.
  */
-function validateManifest(manifest, registryText, uploadDir) {
+function validateManifest(manifest, catalog, uploadDir) {
   const errors = [];
   const warnings = [];
   if (!Array.isArray(manifest)) {
@@ -381,27 +394,27 @@ function validateManifest(manifest, registryText, uploadDir) {
       );
       return;
     }
-    const award = parseAward(registryText, entry.name);
+    const award = lookupAward(catalog, entry.name);
     if (!award) {
       errors.push(
-        `${label}: "${entry.name}" is not present in AwardRegistry.jsx`,
+        `${label}: "${entry.name}" is not present in the award catalog (awardCatalog.js)`,
       );
       return;
     }
-    // A field that is present in the registry but didn't parse must abort,
-    // separate from "name absent" and "not a sheet member": otherwise an award
-    // whose (say) medalPriority failed to parse looks like a non-member, its
-    // medal tile is silently never placed, yet its source is still consumed.
-    const unparsed = unparsedFields(registryText, entry.name);
-    if (unparsed.length > 0) {
+    // A field that is set but unusable must abort, separate from "name absent"
+    // and "not a sheet member": otherwise an award whose (say) medalPriority
+    // holds a bad value looks like a non-member, its medal tile is silently
+    // never placed, yet its source is still consumed.
+    const malformed = malformedFields(award);
+    if (malformed.length > 0) {
       errors.push(
-        `${label}: "${entry.name}" has registry field(s) that are present but could not be parsed (${unparsed.join(", ")}); fix the entry in AwardRegistry.jsx`,
+        `${label}: "${entry.name}" has catalog field(s) that are present but unusable (${malformed.join(", ")}); fix the entry in awardCatalog.js`,
       );
       return;
     }
     if (award.awardType === undefined) {
       errors.push(
-        `${label}: "${entry.name}" has no parseable awardType in AwardRegistry.jsx`,
+        `${label}: "${entry.name}" has no usable awardType in the award catalog`,
       );
       return;
     }
@@ -462,11 +475,11 @@ async function run(paths = DEFAULT_PATHS, log = console) {
     log.log("uniform-uploads/manifest.json is empty — nothing to process.");
     return { processed: 0, warnings: [] };
   }
-  const registryText = fs.readFileSync(paths.registry, "utf8");
+  const catalog = await loadCatalog(paths.catalog);
 
   const { errors, warnings } = validateManifest(
     manifest,
-    registryText,
+    catalog,
     paths.uploadDir,
   );
   if (errors.length > 0) {
@@ -484,7 +497,7 @@ async function run(paths = DEFAULT_PATHS, log = console) {
   const allWarnings = [...warnings];
 
   for (const entry of manifest) {
-    const award = parseAward(registryText, entry.name);
+    const award = lookupAward(catalog, entry.name);
     const replace = entry.replace === true;
     if (onRibbonSheet(award)) {
       const { png, warnings: w } = await normalizeRibbon(
@@ -603,10 +616,10 @@ module.exports = {
   MEDAL,
   RIBBON_SHEET_TYPES,
   MEDAL_SHEET_TYPES,
-  escapeRegExp,
-  extractAwardBody,
-  parseAward,
-  unparsedFields,
+  indexCatalog,
+  loadCatalog,
+  lookupAward,
+  malformedFields,
   onRibbonSheet,
   onMedalSheet,
   readSheet,

--- a/generateAwardSprites.test.js
+++ b/generateAwardSprites.test.js
@@ -1,10 +1,18 @@
 "use strict";
 
 /**
- * Self-contained harness for generateAwardSprites.js. No test framework — run
- * with `node generateAwardSprites.test.js`. Builds synthetic sprite sheets and
+ * Harness for generateAwardSprites.js. No test framework — run with `npm test`
+ * (not a bare `node`; the script carries the flag that mutes Node's
+ * MODULE_TYPELESS_PACKAGE_JSON notice). Builds synthetic sprite sheets and
  * sources in a temp dir so the real sheets are never touched, then asserts the
  * I/O-matrix edge cases from the spec.
+ *
+ * One deliberate exception to "synthetic": the first block of main() loads the
+ * REAL constants/awardCatalog.js and awardTypes.js, read-only. Those
+ * assertions are the entire point of this suite — a fixture cannot catch the
+ * award data moving or changing shape, which is how the generator once sat
+ * broken for a month with every test green. Do not replace them with a
+ * fixture.
  */
 
 const assert = require("assert");
@@ -13,8 +21,12 @@ const os = require("os");
 const path = require("path");
 const sharp = require("sharp");
 
+const { pathToFileURL } = require("url");
+
 const {
   DEFAULT_PATHS,
+  RIBBON_SHEET_TYPES,
+  MEDAL_SHEET_TYPES,
   indexCatalog,
   loadCatalog,
   lookupAward,
@@ -148,9 +160,6 @@ async function main() {
     lookupAward(realCatalog, "Nope") === null,
   );
 
-  // Enum values must survive as the plain strings the sheet-membership sets
-  // are written in. A rename in awardTypes.js that broke this would otherwise
-  // only surface as awards mysteriously landing on neither sheet.
   const realAwards = [...realCatalog.values()];
   ok(
     "real catalog: every entry has a non-empty string awardType",
@@ -165,6 +174,35 @@ async function main() {
   ok(
     "real catalog: at least one award gates onto each sheet",
     realAwards.some(onRibbonSheet) && realAwards.some(onMedalSheet),
+  );
+
+  // The sheet-membership sets are written as plain strings, so they are bound
+  // to awardTypes.js only by convention. Cross-check them against the real
+  // enum: renaming a value there (Ribbon: "Ribbon" -> "RIBBON") would silently
+  // drop every award of that type off its sheet, and no assertion above would
+  // notice, because the survivors of the OTHER types keep every "some(...)"
+  // and "typeof === string" check true. Verified: that exact rename drops 7
+  // real awards off the ribbon sheet with the rest of this suite still green.
+  const { AwardType } = await import(
+    pathToFileURL(
+      path.join(path.dirname(DEFAULT_PATHS.catalog), "awardTypes.js"),
+    ).href
+  );
+  const enumValues = new Set(Object.values(AwardType));
+  const orphanedSetMembers = [
+    ...RIBBON_SHEET_TYPES,
+    ...MEDAL_SHEET_TYPES,
+  ].filter((t) => !enumValues.has(t));
+  assert.deepStrictEqual(orphanedSetMembers, []);
+  ok("real enum: every sheet-membership type is a live AwardType value", true);
+
+  const orphanedCatalogTypes = [
+    ...new Set(realAwards.map((a) => a.awardType)),
+  ].filter((t) => !enumValues.has(t));
+  assert.deepStrictEqual(orphanedCatalogTypes, []);
+  ok(
+    "real enum: every awardType used by the catalog is a live AwardType value",
+    true,
   );
 
   // --- indexCatalog / lookupAward ---
@@ -196,8 +234,30 @@ async function main() {
   assert.throws(() => indexCatalog([{ awardPriority: 1 }]), /name/i);
   ok("indexCatalog: an entry with no name throws", true);
 
+  assert.throws(() => indexCatalog([{ name: "", awardPriority: 1 }]), /name/i);
+  ok("indexCatalog: an empty-string name throws", true);
+
+  // A stray comma or a conditional spread in the catalog array leaves a hole.
+  assert.throws(() => indexCatalog([null]), /name/i);
+  ok("indexCatalog: a null entry throws the catalog-shaped error", true);
+
   assert.throws(() => indexCatalog("not an array"), /array/i);
   ok("indexCatalog: a non-array catalog throws", true);
+
+  // An empty catalog is never a legitimate state, and letting it through
+  // reports every award as "not present" — the same misdirection that hid the
+  // original breakage.
+  assert.throws(() => indexCatalog([]), /empty/i);
+  ok("indexCatalog: an empty catalog throws instead of indexing nothing", true);
+
+  await assert.rejects(
+    loadCatalog(path.join(os.tmpdir(), "no-such-award-catalog.js")),
+    /ERR_MODULE_NOT_FOUND|Cannot find module/,
+  );
+  ok(
+    "loadCatalog: a missing catalog file rejects, never degrades to empty",
+    true,
+  );
 
   // --- malformedFields: present-but-unusable value is flagged ---
   assert.deepStrictEqual(
@@ -416,7 +476,7 @@ async function main() {
     !r.errors.some((e) => e.includes("both a replace and an insert")),
   );
 
-  // --- spliceSheet: two new tiles interleave at their final registry rows ---
+  // --- spliceSheet: two new tiles interleave at their final catalog rows ---
   // Refutes the "multi-insert cascade" review claim: inserting ascending on the
   // growing buffer places each tile at its final position.
   const inter = path.join(dir, "inter.png");
@@ -472,7 +532,7 @@ async function main() {
   assert.deepStrictEqual(await rowColor(appnd, 0), [50, 50, 50]);
   ok("splice: original content preserved before padded append", true);
   assert.deepStrictEqual(await rowColor(appnd, 28), [150, 0, 0]);
-  ok("splice: appended tile lands at its exact registry row y=28", true);
+  ok("splice: appended tile lands at its exact catalog row y=28", true);
 
   // --- spliceSheet: ascending multi-insert, rows below unchanged ---
   const sheet = path.join(dir, "sheet.png");
@@ -483,7 +543,7 @@ async function main() {
   ]); // 3 bands, 42px
   const tileA = await colorTile(43, 14, [100, 0, 0]);
   const tileB = await colorTile(43, 14, [200, 0, 0]);
-  // Insert at registry rows 1 (y=14) and 3 (y=42, append) — final layout.
+  // Insert at catalog rows 1 (y=14) and 3 (y=42, append) — final layout.
   await spliceSheet(sheet, [
     { y: 42, tileHeight: 14, png: tileB, name: "B" },
     { y: 14, tileHeight: 14, png: tileA, name: "A" },
@@ -497,7 +557,7 @@ async function main() {
   assert.deepStrictEqual(await rowColor(sheet, 28), [20, 0, 0]);
   ok("splice: original band 1 shifted down below insert A", true);
   assert.deepStrictEqual(await rowColor(sheet, 42), [200, 0, 0]);
-  ok("splice: tile B landed at its final registry row y=42", true);
+  ok("splice: tile B landed at its final catalog row y=42", true);
   assert.deepStrictEqual(await rowColor(sheet, 56), [30, 0, 0]);
   ok("splice: original last band shifted down below both inserts", true);
 

--- a/generateAwardSprites.test.js
+++ b/generateAwardSprites.test.js
@@ -14,8 +14,11 @@ const path = require("path");
 const sharp = require("sharp");
 
 const {
-  parseAward,
-  unparsedFields,
+  DEFAULT_PATHS,
+  indexCatalog,
+  loadCatalog,
+  lookupAward,
+  malformedFields,
   onRibbonSheet,
   onMedalSheet,
   validateManifest,
@@ -24,19 +27,46 @@ const {
   run,
 } = require("./generateAwardSprites");
 
-const REGISTRY = `
-  // prettier-ignore
-  initalizeAwards() {
-    this.awards.set("Lifetime Medal", {awardPriority: 0, medalPriority: 0, awardType: "Medal"});
-    this.awards.set("Foo Ribbon", {awardPriority: 1, awardType: "Ribbon"});
-    this.awards.set("Bar Medal", {awardPriority: 2, medalPriority:2, awardType: "Medal"});
-    this.awards.set(\`Baz "Q" Service Ribbon\`, {awardPriority: 4, medalPriority: 3, awardType: "Medal"});
-    this.awards.set("Ranger Tab", {awardPriority: 1, awardType: "Tab"});
-    this.awards.set("Nested Medal", {awardPriority: 5, style: {x: 1}, medalPriority: 4, awardType: "Medal"});
-    this.awards.set("Broken Medal", {awardPriority: 6, medalPriority: WIP, awardType: "Medal"});
-    this.awards.set("Typeless Medal", {awardPriority: 7, medalPriority: 6});
-  }
-`;
+// Synthetic stand-in for AWARD_CATALOG, in the real catalog's shape: an ordered
+// array of plain objects keyed by `name`. Shared by the in-memory Map fixture
+// and the on-disk ESM module that run() imports, so both exercise the same
+// data through the same indexing code the generator uses in production.
+const CATALOG_ENTRIES = [
+  {
+    name: "Lifetime Medal",
+    awardPriority: 0,
+    medalPriority: 0,
+    awardType: "Medal",
+  },
+  { name: "Foo Ribbon", awardPriority: 1, awardType: "Ribbon" },
+  { name: "Bar Medal", awardPriority: 2, medalPriority: 2, awardType: "Medal" },
+  {
+    name: `Baz "Q" Service Ribbon`,
+    awardPriority: 4,
+    medalPriority: 3,
+    awardType: "Medal",
+  },
+  { name: "Ranger Tab", awardPriority: 1, awardType: "Tab" },
+  // Carries an unrelated nested field: extra keys must not disturb placement.
+  {
+    name: "Nested Medal",
+    awardPriority: 5,
+    style: { x: 1 },
+    medalPriority: 4,
+    awardType: "Medal",
+  },
+  // medalPriority is present but not a usable row index — must be rejected
+  // loudly rather than read as "no medal tile".
+  {
+    name: "Broken Medal",
+    awardPriority: 6,
+    medalPriority: "WIP",
+    awardType: "Medal",
+  },
+  { name: "Typeless Medal", awardPriority: 7, medalPriority: 6 },
+];
+
+const CATALOG = indexCatalog(CATALOG_ENTRIES);
 
 // Solid-color RGBA tile as a PNG buffer.
 function colorTile(width, height, [r, g, b]) {
@@ -90,64 +120,148 @@ function ok(name, cond) {
 }
 
 async function main() {
-  // --- parseAward ---
-  assert.deepStrictEqual(parseAward(REGISTRY, "Foo Ribbon"), {
+  // --- REAL catalog: the guard this whole rewrite exists for ---
+  // History: the generator used to parse AwardRegistry.jsx as text. PR #130
+  // moved the award data into constants/awardCatalog.js and the text matcher
+  // silently matched nothing — every upload failed "not present in
+  // AwardRegistry.jsx" while this suite stayed green, because every other test
+  // here runs against synthetic fixtures. These assertions run against the
+  // REAL catalog, so the next time that data moves or changes shape, it fails
+  // at merge time instead of in front of a contributor.
+  const realCatalog = await loadCatalog(DEFAULT_PATHS.catalog);
+  ok("real catalog: loads a non-empty catalog", realCatalog.size > 50);
+
+  const dsc = lookupAward(realCatalog, "Army Distinguished Service Cross");
+  ok(
+    "real catalog: a known award resolves with usable placement fields",
+    dsc !== null &&
+      Number.isInteger(dsc.awardPriority) &&
+      Number.isInteger(dsc.medalPriority) &&
+      dsc.awardType === "Medal",
+  );
+  ok(
+    "real catalog: that award gates onto both sheets",
+    onRibbonSheet(dsc) && onMedalSheet(dsc),
+  );
+  ok(
+    "real catalog: an absent name resolves to null",
+    lookupAward(realCatalog, "Nope") === null,
+  );
+
+  // Enum values must survive as the plain strings the sheet-membership sets
+  // are written in. A rename in awardTypes.js that broke this would otherwise
+  // only surface as awards mysteriously landing on neither sheet.
+  const realAwards = [...realCatalog.values()];
+  ok(
+    "real catalog: every entry has a non-empty string awardType",
+    realAwards.every(
+      (a) => typeof a.awardType === "string" && a.awardType !== "",
+    ),
+  );
+  ok(
+    "real catalog: no entry has a malformed placement field",
+    realAwards.every((a) => malformedFields(a).length === 0),
+  );
+  ok(
+    "real catalog: at least one award gates onto each sheet",
+    realAwards.some(onRibbonSheet) && realAwards.some(onMedalSheet),
+  );
+
+  // --- indexCatalog / lookupAward ---
+  assert.deepStrictEqual(lookupAward(CATALOG, "Foo Ribbon"), {
+    name: "Foo Ribbon",
     awardPriority: 1,
     awardType: "Ribbon",
   });
-  ok("parseAward: ribbon-only has awardPriority, no medalPriority", true);
+  ok("lookup: ribbon-only has awardPriority, no medalPriority", true);
 
-  assert.deepStrictEqual(parseAward(REGISTRY, "Bar Medal"), {
-    awardPriority: 2,
-    medalPriority: 2,
-    awardType: "Medal",
-  });
-  ok("parseAward: tolerates `medalPriority:2` with no space", true);
+  assert.strictEqual(lookupAward(CATALOG, "Nope"), null);
+  ok("lookup: absent name returns null", true);
 
-  assert.deepStrictEqual(parseAward(REGISTRY, 'Baz "Q" Service Ribbon'), {
-    awardPriority: 4,
-    medalPriority: 3,
-    awardType: "Medal",
-  });
-  ok("parseAward: backtick name with embedded quotes + awardType", true);
+  assert.strictEqual(
+    lookupAward(CATALOG, 'Baz "Q" Service Ribbon').medalPriority,
+    3,
+  );
+  ok("lookup: name with embedded quotes resolves", true);
 
-  assert.strictEqual(parseAward(REGISTRY, "Nope"), null);
-  ok("parseAward: absent name returns null", true);
+  assert.strictEqual(lookupAward(CATALOG, "Nested Medal").medalPriority, 4);
+  ok("lookup: an unrelated nested field does not disturb placement", true);
 
-  // Brace-balanced extraction: a nested object before the priorities must not
-  // truncate the entry and drop its trailing fields.
-  assert.deepStrictEqual(parseAward(REGISTRY, "Nested Medal"), {
-    awardPriority: 5,
-    medalPriority: 4,
-    awardType: "Medal",
-  });
-  ok("parseAward: nested object before priorities does not truncate", true);
+  assert.throws(
+    () => indexCatalog([{ name: "Dup" }, { name: "Dup" }]),
+    /duplicate/i,
+  );
+  ok("indexCatalog: a duplicate award name throws", true);
 
-  // --- unparsedFields: present-but-unparsed field is flagged ---
-  assert.deepStrictEqual(unparsedFields(REGISTRY, "Broken Medal"), [
-    "medalPriority",
+  assert.throws(() => indexCatalog([{ awardPriority: 1 }]), /name/i);
+  ok("indexCatalog: an entry with no name throws", true);
+
+  assert.throws(() => indexCatalog("not an array"), /array/i);
+  ok("indexCatalog: a non-array catalog throws", true);
+
+  // --- malformedFields: present-but-unusable value is flagged ---
+  assert.deepStrictEqual(
+    malformedFields(lookupAward(CATALOG, "Broken Medal")),
+    ["medalPriority"],
+  );
+  ok("malformed: present-but-unusable medalPriority is flagged", true);
+  assert.deepStrictEqual(
+    malformedFields(lookupAward(CATALOG, "Bar Medal")),
+    [],
+  );
+  ok("malformed: clean entry flags nothing", true);
+  assert.deepStrictEqual(
+    malformedFields({ awardPriority: -1, awardType: "Medal" }),
+    ["awardPriority"],
+  );
+  ok("malformed: a negative row index is flagged", true);
+
+  // A field WRITTEN as undefined (what a typo'd or deleted enum reference
+  // evaluates to) states an intent to sit on that sheet, so it must be
+  // rejected — not read as "field omitted", which would splice the ribbon
+  // tile, skip the medal tile, and still exit 0.
+  assert.deepStrictEqual(
+    malformedFields({
+      awardPriority: 1,
+      medalPriority: undefined,
+      awardType: "Medal",
+    }),
+    ["medalPriority"],
+  );
+  ok(
+    "malformed: a field written as undefined is flagged, not read as absent",
+    true,
+  );
+
+  assert.deepStrictEqual(
+    malformedFields({ awardPriority: 1, awardType: "Medal" }),
+    [],
+  );
+  ok(
+    "malformed: an omitted field is a legitimate non-member, not flagged",
+    true,
+  );
+
+  assert.deepStrictEqual(malformedFields({ awardPriority: 1, awardType: "" }), [
+    "awardType",
   ]);
-  ok("unparsed: present-but-unparseable medalPriority is flagged", true);
-  assert.deepStrictEqual(unparsedFields(REGISTRY, "Bar Medal"), []);
-  ok("unparsed: clean entry flags nothing", true);
-  assert.deepStrictEqual(unparsedFields(REGISTRY, "Nope"), []);
-  ok("unparsed: absent name flags nothing", true);
+  ok("malformed: an empty-string awardType is flagged", true);
 
   // --- membership gating ---
   ok(
     "membership: Tab is on neither sheet",
-    !onRibbonSheet(parseAward(REGISTRY, "Ranger Tab")) &&
-      !onMedalSheet(parseAward(REGISTRY, "Ranger Tab")),
+    !onRibbonSheet(lookupAward(CATALOG, "Ranger Tab")) &&
+      !onMedalSheet(lookupAward(CATALOG, "Ranger Tab")),
   );
   ok(
     "membership: Lifetime medal (medalPriority 0) is ribbon-only, not on medal sheet",
-    onRibbonSheet(parseAward(REGISTRY, "Lifetime Medal")) &&
-      !onMedalSheet(parseAward(REGISTRY, "Lifetime Medal")),
+    onRibbonSheet(lookupAward(CATALOG, "Lifetime Medal")) &&
+      !onMedalSheet(lookupAward(CATALOG, "Lifetime Medal")),
   );
   ok(
     "membership: service ribbon is on both sheets",
-    onRibbonSheet(parseAward(REGISTRY, 'Baz "Q" Service Ribbon')) &&
-      onMedalSheet(parseAward(REGISTRY, 'Baz "Q" Service Ribbon')),
+    onRibbonSheet(lookupAward(CATALOG, 'Baz "Q" Service Ribbon')) &&
+      onMedalSheet(lookupAward(CATALOG, 'Baz "Q" Service Ribbon')),
   );
 
   // --- validateManifest ---
@@ -163,37 +277,59 @@ async function main() {
 
   let r = validateManifest(
     [{ name: "Ghost", ribbon: "ribbon.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
-  ok("validate: name absent from registry errors", r.errors.length === 1);
+  ok("validate: name absent from the catalog errors", r.errors.length === 1);
 
   r = validateManifest(
     [{ name: "Broken Medal", ribbon: "ribbon.png", medal: "medal.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
-    "validate: present-but-unparsed field is a hard error, not a non-member",
+    "validate: present-but-unusable field is a hard error, not a non-member",
     r.errors.some(
-      (e) => e.includes("could not be parsed") && e.includes("medalPriority"),
+      (e) => e.includes("present but unusable") && e.includes("medalPriority"),
+    ),
+  );
+
+  // Built inline rather than added to CATALOG_ENTRIES: JSON.stringify drops
+  // undefined-valued keys, so this entry would not survive writeCatalog() and
+  // the on-disk fixture would disagree with the in-memory one.
+  r = validateManifest(
+    [{ name: "Phantom Medal", ribbon: "ribbon.png", medal: "medal.png" }],
+    indexCatalog([
+      {
+        name: "Phantom Medal",
+        awardPriority: 8,
+        medalPriority: undefined,
+        awardType: "Medal",
+      },
+    ]),
+    dir,
+  );
+  ok(
+    "validate: a medalPriority written as undefined aborts the run, not just the medal tile",
+    r.errors.some(
+      (e) => e.includes("present but unusable") && e.includes("medalPriority"),
     ),
   );
 
   r = validateManifest(
     [{ name: "Typeless Medal", ribbon: "ribbon.png", medal: "medal.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
     "validate: priorities present but no awardType errors distinctly (not 'does not belong')",
-    r.errors.some((e) => e.includes("no parseable awardType")) &&
+    r.errors.some((e) => e.includes("no usable awardType")) &&
       !r.errors.some((e) => e.includes("does not belong")),
   );
 
   r = validateManifest(
     [{ name: "Bar Medal", ribbon: "ribbon.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
@@ -203,14 +339,14 @@ async function main() {
 
   r = validateManifest(
     [{ name: "Foo Ribbon", ribbon: "ribbon.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok("validate: ribbon-only with its source passes", r.errors.length === 0);
 
   r = validateManifest(
     [{ name: "Bar Medal", ribbon: "ribbon.png", medal: "medal.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
@@ -220,7 +356,7 @@ async function main() {
 
   r = validateManifest(
     [{ name: "Foo Ribbon", ribbon: "ribbon.png", medal: "medal.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
@@ -230,7 +366,7 @@ async function main() {
 
   r = validateManifest(
     [{ name: "Ranger Tab", ribbon: "ribbon.png" }],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
@@ -243,7 +379,7 @@ async function main() {
       { name: "Foo Ribbon", ribbon: "ribbon.png" },
       { name: "Foo Ribbon", ribbon: "ribbon.png" },
     ],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
@@ -258,7 +394,7 @@ async function main() {
       { name: "Foo Ribbon", ribbon: "ribbon.png", replace: true },
       { name: "Lifetime Medal", ribbon: "ribbon.png" },
     ],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
@@ -272,7 +408,7 @@ async function main() {
       { name: "Foo Ribbon", ribbon: "ribbon.png", replace: true },
       { name: "Lifetime Medal", ribbon: "ribbon.png", replace: true },
     ],
-    REGISTRY,
+    CATALOG,
     dir,
   );
   ok(
@@ -675,15 +811,30 @@ function makePaths(dir) {
   return {
     uploadDir: dir,
     manifest: path.join(dir, "manifest.json"),
-    registry: writeRegistry(dir),
+    catalog: writeCatalog(dir),
     ribbonSheet: path.join(dir, "ribbonSheet.png"),
     medalSheet: path.join(dir, "medalSheet.png"),
   };
 }
 
-function writeRegistry(dir) {
-  const p = path.join(dir, "AwardRegistry.jsx");
-  fs.writeFileSync(p, REGISTRY);
+/**
+ * Write CATALOG_ENTRIES out as a standalone ES module for run() to import.
+ * Self-contained (values inlined, no imports) so it loads from a temp dir with
+ * no package.json.
+ *
+ * Two constraints if you extend this. Node caches ES modules by URL and never
+ * invalidates, so a second catalog with DIFFERENT contents must be written to a
+ * different directory or the first one is served again. And JSON.stringify
+ * drops undefined-valued keys, so a fixture testing a field written as
+ * `undefined` cannot round-trip through here — build it inline with
+ * indexCatalog() instead.
+ */
+function writeCatalog(dir) {
+  const p = path.join(dir, "awardCatalog.js");
+  fs.writeFileSync(
+    p,
+    `export const AWARD_CATALOG = ${JSON.stringify(CATALOG_ENTRIES, null, 2)};\n`,
+  );
   return p;
 }
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "scripts": {
     "format:check": "prettier --check \"{**/*,*}.{js,jsx,json,html,css}\"",
     "format": "prettier --write \"{**/*,*}.{js,jsx,json,html,css}\"",
-    "sprites:generate": "node generateAwardSprites.js",
-    "test": "node generateAwardSprites.test.js"
+    "sprites:generate": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON generateAwardSprites.js",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON generateAwardSprites.test.js"
   },
   "devDependencies": {
     "prettier": "3.8.3",
     "sharp": "^0.34.4"
+  },
+  "engines": {
+    "node": ">=22.7"
   }
 }

--- a/uniform-uploads/README.md
+++ b/uniform-uploads/README.md
@@ -30,8 +30,12 @@ the sprite sheets and opens a pull request for review.
 
    - `name` must match the catalog award name exactly.
    - Supply `ribbon` if the award has an `awardPriority`, and `medal` if it has
-     a `medalPriority`. Service ribbons have both; pure ribbons have only
-     `ribbon`.
+     a `medalPriority` of 2 or higher. Service ribbons have both; pure ribbons
+     have only `ribbon`. Priorities 0 and 1 are the two Lifetime medals, which
+     sit on the ribbon sheet only.
+   - Only mainline medals and ribbons live in these two sheets. Badges, tabs,
+     weapon quals and unit citations render from separate assets and cannot be
+     uploaded here, even though they carry an `awardPriority`.
 
 4. **Push.** CI validates the manifest against the catalog, splices the tiles
    into the sprite sheets at the catalog-derived rows, removes the consumed
@@ -57,8 +61,8 @@ Two modes, selected per entry:
   ```json
   [
     {
-      "name": "Combat Action Badge",
-      "medal": "CAB_v2.png",
+      "name": "Army Distinguished Service Cross",
+      "medal": "ADSC_v2.png",
       "replace": true
     }
   ]

--- a/uniform-uploads/README.md
+++ b/uniform-uploads/README.md
@@ -6,10 +6,11 @@ the sprite sheets and opens a pull request for review.
 
 ## How to add an award
 
-1. **Edit the registry first.** Add (and renumber) the award in
-   `client/app/uniformbuilder/modules/AwardRegistry.jsx`. This is the single
-   source of truth for placement — CI reads `awardPriority` / `medalPriority`
-   from it; the manifest never restates row numbers.
+1. **Edit the catalog first.** Add (and renumber) the award in
+   `client/app/uniformbuilder/modules/constants/awardCatalog.js`. This is the
+   single source of truth for placement — CI imports the same module the
+   uniform builder renders from and reads `awardPriority` / `medalPriority`
+   off it; the manifest never restates row numbers.
 2. **Drop the source art** here as PNG(s):
    - Ribbon art: ideally 43×13, RGB or RGBA (it is vertically stretched to
      43×14).
@@ -27,17 +28,17 @@ the sprite sheets and opens a pull request for review.
    ]
    ```
 
-   - `name` must match the registry award name exactly.
+   - `name` must match the catalog award name exactly.
    - Supply `ribbon` if the award has an `awardPriority`, and `medal` if it has
      a `medalPriority`. Service ribbons have both; pure ribbons have only
      `ribbon`.
 
-4. **Push.** CI validates the manifest against the registry, splices the tiles
-   into the sprite sheets at the registry-derived rows, removes the consumed
+4. **Push.** CI validates the manifest against the catalog, splices the tiles
+   into the sprite sheets at the catalog-derived rows, removes the consumed
    PNGs, empties the manifest, and opens a PR containing only the regenerated
    sheets and this cleanup. Review and merge it.
 
-CI never edits the registry, never touches the `.xcf` GIMP sources, and never
+CI never edits the catalog, never touches the `.xcf` GIMP sources, and never
 auto-merges.
 
 ## Adding new art vs. fixing existing art
@@ -45,11 +46,11 @@ auto-merges.
 Two modes, selected per entry:
 
 - **New award (default) — insert.** Omit `replace` (or set it to `false`). CI
-  splices the tile in at the registry-derived row and shifts every row below it
+  splices the tile in at the catalog-derived row and shifts every row below it
   down by one tile. Use this only for an award that is **new to the sheet**, and
-  renumber the registry as in step 1 so the priorities below it move too.
+  renumber the catalog as in step 1 so the priorities below it move too.
 - **Existing award — replace.** Set `"replace": true`. CI overwrites the tile
-  already at that award's registry row in place — no shift, no height change —
+  already at that award's catalog row in place — no shift, no height change —
   so re-uploading art for an award that already has a tile fixes it instead of
   inserting a duplicate.
 
@@ -63,6 +64,6 @@ Two modes, selected per entry:
   ]
   ```
 
-  Do **not** renumber the registry for a replace — the award keeps its existing
+  Do **not** renumber the catalog for a replace — the award keeps its existing
   priority. Replacing a row that doesn't exist yet (a priority past the end of
   the sheet) fails the run; use an insert for a genuinely new award.


### PR DESCRIPTION
## What

The award sprite generator has been non-functional since #130 merged. This repairs it and adds the test that would have caught the breakage at merge time.

## The bug

`generateAwardSprites.js` read each award's `awardPriority` / `medalPriority` / `awardType` by matching `AwardRegistry.jsx` as text:

```js
'this\\.awards\\.set\\(\\s*[`"]' + escaped + '[`"]\\s*,\\s*\\{'
```

#130 moved that data into `constants/awardCatalog.js` and reduced the registry to a loop over `AWARD_CATALOG`. The matcher then found nothing, and every upload failed with:

```
ERROR: entry 0: "Army Distinguished Service Cross" is not present in AwardRegistry.jsx
manifest validation failed (1 error(s)); no sprite sheet was modified
```

Git had nothing to flag. The two PRs touched disjoint files, so the merge was clean. It was a semantic conflict, not a textual one.

Nothing caught it afterwards either. `manifest.json` ships empty, so the CI generate step is a no-op, and every test ran against a synthetic fixture shaped like the old file. `npm test` was already wired into `lint_format.yml` when #130 merged. It ran, it passed, and the breakage shipped.

## The fix

Import the catalog instead of matching it as text. The generator now reads the same module the uniform builder renders from, so the two cannot drift apart again. That removes the regex layer entirely: `escapeRegExp`, `extractAwardBody`, `parseAward`, `unparsedFields` and `FIELD_RE` are gone, replaced by `loadCatalog`, `indexCatalog`, `lookupAward` and `malformedFields`.

The behaviour contract from #139 is unchanged. Sheet membership is still `awardType`-gated on the same sets, the splice is still raw-byte concatenation, all validation still runs before any image is written, and both sheets are still computed before either is encoded.

Two details worth review attention:

**`malformedFields` keys on whether a field is written, not on `!== undefined`.** Omitting `medalPriority` is the legitimate way to express a ribbon-only award, but an entry that spells the key out and lands on `undefined` has declared an intent to sit on the medal sheet. Collapsing those two would splice the ribbon tile, skip the medal tile, and exit 0. `Object.hasOwn` keeps them distinct, which is what the old text matcher did by checking for the key in the source.

**`client/package.json` deliberately keeps no `"type"` field.** Node suggests adding `"type": "module"` there to silence its `MODULE_TYPELESS_PACKAGE_JSON` notice, but `client/next.config.js` is CommonJS and would break. The imports in `awardCatalog.js` carry explicit `.js` instead (5 lines, the only client change in this PR), the npm scripts carry `--disable-warning` for that one notice, and `engines: node >=22.7` records the floor that both the flag and Node's ESM syntax detection need.

## Verification

- 77 assertions pass (was 58). Prettier passes. `next build` passes, including `/uniformbuilder`.
- The suite now loads the **real** `awardCatalog.js` and asserts a known award resolves. Renaming the file, renaming the export, or reshaping the array all fail the suite. A fixture cannot satisfy it, which is the point.
- The sheet-membership sets and every `awardType` the catalog uses are cross-checked against `awardTypes.js`. Renaming `AwardType.Ribbon` to `"RIBBON"` would silently drop 7 awards off the ribbon sheet, and now fails the suite instead.
- Run against copies of the production sheets: `replace` leaves both heights unchanged (783 / 5401), `insert` grows ribbon by 14px and medal by 120px at the right rows, alpha survives, rows above the insert stay byte-identical, sources are consumed and the manifest is emptied.

## Notes

Only `awardCatalog.js` carries import extensions. The other files in `constants/` are never in the generator's import graph, so they are left alone.

> *This was generated by AI*
