### PR TITLE
fix(uniformbuilder): fail loudly on two silent failures in the award sprite generator

### DIFF
--- a/generateAwardSprites.js
+++ b/generateAwardSprites.js
@@ -177,8 +177,10 @@ const FIELD_IS_USABLE = {
  *
  * Guards the dangerous case: a field set to something unusable would otherwise
  * read as "field not set," making the award look like a non-member of that
- * sheet — its tile never placed, reported only as the misleading "does not
- * belong to this sheet".
+ * sheet. The manifest-side check catches this too whenever a source for that
+ * sheet is supplied, so what survives here is the case where none is: the
+ * award silently loses a tile it was meant to have, and the operator is told
+ * it is not on that sheet rather than that the field is broken.
  *
  * Keyed on whether the field is WRITTEN, not on `!== undefined`, because the
  * two mean opposite things here. An entry that omits `medalPriority` is a
@@ -388,16 +390,17 @@ async function spliceSheet(sheetPath, inserts) {
  * Why the catalog does not place this award on `kind`'s sheet, phrased for a
  * contributor who has just asserted the opposite by supplying art for it.
  *
- * The ribbon side has only one possible answer. An award only reaches here if
- * it is a member of the OTHER sheet (a non-member of both already errored), and
- * MEDAL_SHEET_TYPES is a subset of RIBBON_SHEET_TYPES, so a medal-sheet member
- * necessarily has a ribbon-sheet awardType — the missing piece is the priority.
+ * Checks the reasons in the same order membership is gated, rather than
+ * shortcutting on what the caller has already ruled out. A wrong reason is
+ * worse here than no reason: it sends someone to fix a field that was never
+ * the problem, and the caller's preconditions are not visible from inside.
  */
 function sheetExclusionReason(award, kind) {
-  if (kind === "ribbon") return "it has no awardPriority";
-  if (!MEDAL_SHEET_TYPES.has(award.awardType)) {
-    return `its awardType "${award.awardType}" is not one of ${[...MEDAL_SHEET_TYPES].join(", ")}`;
+  const types = kind === "ribbon" ? RIBBON_SHEET_TYPES : MEDAL_SHEET_TYPES;
+  if (!types.has(award.awardType)) {
+    return `its awardType "${award.awardType}" is not one of ${[...types].join(", ")}`;
   }
+  if (kind === "ribbon") return "it has no awardPriority";
   if (award.medalPriority === undefined) return "it has no medalPriority";
   return `its medalPriority ${award.medalPriority} is below ${MEDAL_MIN_PRIORITY}, the sheet's first row`;
 }
@@ -406,8 +409,8 @@ function sheetExclusionReason(award, kind) {
 // ignored, because `replace` is read as a strict `=== true`: a near-miss
 // spelling ("replaced") reads as absent, which quietly downgrades a replace
 // into an insert and shifts every row below the target down by one tile. That
-// is the same corruption the replace/insert mix guard exists to prevent, but
-// arriving with no diagnostic at all.
+// is the same class of silent row divergence the replace/insert mix guard
+// exists to prevent, reached by a different route and with no diagnostic.
 const MANIFEST_KEYS = ["name", "ribbon", "medal", "replace"];
 
 /**
@@ -468,8 +471,9 @@ function validateManifest(manifest, catalog, uploadDir) {
     }
     // A field that is set but unusable must abort, separate from "name absent"
     // and "not a sheet member": otherwise an award whose (say) medalPriority
-    // holds a bad value looks like a non-member, its medal tile is silently
-    // never placed, yet its source is still consumed.
+    // holds a bad value looks like a non-member. With no medal source supplied
+    // there is nothing else to notice the mismatch, so the ribbon tile goes in,
+    // its source is consumed, and the medal tile is silently never placed.
     const malformed = malformedFields(award);
     if (malformed.length > 0) {
       errors.push(
@@ -505,12 +509,12 @@ function validateManifest(manifest, catalog, uploadDir) {
       } else if (entry[kind]) {
         // Two humans contradicting each other, not a stray file: the manifest
         // asserts this award has art for this sheet, the catalog gives it
-        // nowhere to go. Warning and continuing placed the OTHER tile, deleted
-        // its source and emptied the manifest, so the award shipped
-        // half-placed with the warning reading as "correct, this one is
-        // ribbon-only". An omitted priority is the legitimate way to say "no
-        // tile on that sheet", so the supplied source is the only signal that
-        // says otherwise — it must not be discarded.
+        // nowhere to go. Warning here would place the other tile, consume that
+        // tile's source and empty the manifest, shipping the award half-placed
+        // while the warning reads as "correct, this one is ribbon-only". An
+        // omitted priority is the legitimate way to say "no tile on that
+        // sheet", so the supplied source is the only signal saying otherwise
+        // and it must not be discarded.
         errors.push(
           `${label}: "${entry.name}" supplies a "${kind}" source but the catalog does not ` +
             `place it on the ${kind} sheet — ${sheetExclusionReason(award, kind)}. Either fix ` +

--- a/generateAwardSprites.js
+++ b/generateAwardSprites.js
@@ -385,16 +385,46 @@ async function spliceSheet(sheetPath, inserts) {
 }
 
 /**
+ * Why the catalog does not place this award on `kind`'s sheet, phrased for a
+ * contributor who has just asserted the opposite by supplying art for it.
+ *
+ * The ribbon side has only one possible answer. An award only reaches here if
+ * it is a member of the OTHER sheet (a non-member of both already errored), and
+ * MEDAL_SHEET_TYPES is a subset of RIBBON_SHEET_TYPES, so a medal-sheet member
+ * necessarily has a ribbon-sheet awardType — the missing piece is the priority.
+ */
+function sheetExclusionReason(award, kind) {
+  if (kind === "ribbon") return "it has no awardPriority";
+  if (!MEDAL_SHEET_TYPES.has(award.awardType)) {
+    return `its awardType "${award.awardType}" is not one of ${[...MEDAL_SHEET_TYPES].join(", ")}`;
+  }
+  if (award.medalPriority === undefined) return "it has no medalPriority";
+  return `its medalPriority ${award.medalPriority} is below ${MEDAL_MIN_PRIORITY}, the sheet's first row`;
+}
+
+// Every key a manifest entry may carry. Anything else is rejected rather than
+// ignored, because `replace` is read as a strict `=== true`: a near-miss
+// spelling ("replaced") reads as absent, which quietly downgrades a replace
+// into an insert and shifts every row below the target down by one tile. That
+// is the same corruption the replace/insert mix guard exists to prevent, but
+// arriving with no diagnostic at all.
+const MANIFEST_KEYS = ["name", "ribbon", "medal", "replace"];
+
+/**
  * Validate the manifest against the award catalog (a name-indexed Map from
- * {@link loadCatalog}). Returns { errors, warnings }; `errors` non-empty means
- * the run must abort before any image is written.
+ * {@link loadCatalog}). Returns { errors }; non-empty means the run must abort
+ * before any image is written.
+ *
+ * Every condition here is an error, never a warning. This tool deletes its
+ * sources and empties the manifest on success, and CI opens a PR from that, so
+ * a warning is indistinguishable from approval by the time anyone reads it —
+ * the inputs that would prove something was skipped are already gone.
  */
 function validateManifest(manifest, catalog, uploadDir) {
   const errors = [];
-  const warnings = [];
   if (!Array.isArray(manifest)) {
     errors.push("manifest.json must be a JSON array of entries");
-    return { errors, warnings };
+    return { errors };
   }
   const seen = new Set();
   // Per-sheet record of which placement modes appear (true = replace, false =
@@ -413,6 +443,16 @@ function validateManifest(manifest, catalog, uploadDir) {
       return;
     }
     seen.add(entry.name);
+    const unknown = Object.keys(entry).filter(
+      (k) => !MANIFEST_KEYS.includes(k),
+    );
+    if (unknown.length > 0) {
+      errors.push(
+        `${label}: "${entry.name}" has unrecognised key(s) (${unknown.join(", ")}); ` +
+          `allowed keys are ${MANIFEST_KEYS.join(", ")} — check the spelling`,
+      );
+      return;
+    }
     if (entry.replace !== undefined && typeof entry.replace !== "boolean") {
       errors.push(
         `${label}: "${entry.name}" has a non-boolean "replace" (must be true or false)`,
@@ -463,8 +503,18 @@ function validateManifest(manifest, catalog, uploadDir) {
           );
         }
       } else if (entry[kind]) {
-        warnings.push(
-          `${label}: "${entry.name}" does not belong to the ${kind} sheet; ignoring its "${kind}" source`,
+        // Two humans contradicting each other, not a stray file: the manifest
+        // asserts this award has art for this sheet, the catalog gives it
+        // nowhere to go. Warning and continuing placed the OTHER tile, deleted
+        // its source and emptied the manifest, so the award shipped
+        // half-placed with the warning reading as "correct, this one is
+        // ribbon-only". An omitted priority is the legitimate way to say "no
+        // tile on that sheet", so the supplied source is the only signal that
+        // says otherwise — it must not be discarded.
+        errors.push(
+          `${label}: "${entry.name}" supplies a "${kind}" source but the catalog does not ` +
+            `place it on the ${kind} sheet — ${sheetExclusionReason(award, kind)}. Either fix ` +
+            `the award in awardCatalog.js, or drop "${kind}" from this manifest entry.`,
         );
       }
     };
@@ -486,7 +536,7 @@ function validateManifest(manifest, catalog, uploadDir) {
       );
     }
   });
-  return { errors, warnings };
+  return { errors };
 }
 
 /** Write the manifest array back prettier-clean (2-space, trailing newline). */
@@ -502,11 +552,7 @@ async function run(paths = DEFAULT_PATHS, log = console) {
   }
   const catalog = await loadCatalog(paths.catalog);
 
-  const { errors, warnings } = validateManifest(
-    manifest,
-    catalog,
-    paths.uploadDir,
-  );
+  const { errors } = validateManifest(manifest, catalog, paths.uploadDir);
   if (errors.length > 0) {
     errors.forEach((e) => log.error(`ERROR: ${e}`));
     throw new Error(
@@ -519,7 +565,8 @@ async function run(paths = DEFAULT_PATHS, log = console) {
   const ribbonInserts = [];
   const medalInserts = [];
   const consumed = new Set();
-  const allWarnings = [...warnings];
+  // Only the normalizers warn now — geometry that was accepted but reshaped.
+  const allWarnings = [];
 
   for (const entry of manifest) {
     const award = lookupAward(catalog, entry.name);

--- a/generateAwardSprites.test.js
+++ b/generateAwardSprites.test.js
@@ -205,6 +205,18 @@ async function main() {
     true,
   );
 
+  // Every medal-sheet type is also a ribbon-sheet type. sheetExclusionReason
+  // leans on this to answer the ribbon side with a single fixed reason: an
+  // award reaching it is always a medal-sheet member, so its awardType is
+  // necessarily a ribbon type and only the priority can be missing. Add a type
+  // to MEDAL_SHEET_TYPES alone and that reason silently becomes a wrong
+  // diagnosis rather than a failure, so pin the premise here.
+  const medalTypesOffRibbonSheet = [...MEDAL_SHEET_TYPES].filter(
+    (t) => !RIBBON_SHEET_TYPES.has(t),
+  );
+  assert.deepStrictEqual(medalTypesOffRibbonSheet, []);
+  ok("membership: every medal-sheet type is also a ribbon-sheet type", true);
+
   // --- indexCatalog / lookupAward ---
   assert.deepStrictEqual(lookupAward(CATALOG, "Foo Ribbon"), {
     name: "Foo Ribbon",
@@ -414,14 +426,85 @@ async function main() {
     r.errors.length === 0,
   );
 
+  // Supplying art for a sheet the catalog does not place the award on is a
+  // contradiction between two humans' intent, not a stray file: the manifest
+  // asserts the tile exists, the catalog says it has nowhere to go. Warning and
+  // continuing placed the other tile, consumed its source and exited 0, leaving
+  // an award half-placed with the warning reading as "correct, ribbon-only".
   r = validateManifest(
     [{ name: "Foo Ribbon", ribbon: "ribbon.png", medal: "medal.png" }],
     CATALOG,
     dir,
   );
   ok(
-    "validate: extra source for a sheet it doesn't belong to warns",
-    r.warnings.length === 1,
+    "validate: a medal source for a pure ribbon errors, not warns",
+    r.errors.some(
+      (e) => e.includes("medal sheet") && e.includes("awardType"),
+    ) && r.errors.length === 1,
+  );
+
+  // The headline shape: a medal whose medalPriority the contributor forgot to
+  // add. Omitting it is the legitimate way to write a ribbon-only award, so the
+  // supplied "medal" source is the only thing distinguishing the two.
+  r = validateManifest(
+    [{ name: "Forgetful Medal", ribbon: "ribbon.png", medal: "medal.png" }],
+    indexCatalog([
+      { name: "Forgetful Medal", awardPriority: 3, awardType: "Medal" },
+    ]),
+    dir,
+  );
+  ok(
+    "validate: a medal source for a medal missing medalPriority errors",
+    r.errors.some(
+      (e) => e.includes("medal sheet") && e.includes("no medalPriority"),
+    ),
+  );
+
+  // A medalPriority on a non-medal awardType is not a medal tile: membership is
+  // gated on type first, so the priority is inert and the art has nowhere to go.
+  r = validateManifest(
+    [{ name: "Priced Ribbon", ribbon: "ribbon.png", medal: "medal.png" }],
+    indexCatalog([
+      {
+        name: "Priced Ribbon",
+        awardPriority: 3,
+        medalPriority: 5,
+        awardType: "Ribbon",
+      },
+    ]),
+    dir,
+  );
+  ok(
+    "validate: a medal source for a ribbon carrying a medalPriority errors",
+    r.errors.some((e) => e.includes("medal sheet") && e.includes("awardType")),
+  );
+
+  // Priorities 0 and 1 are the two Lifetime medals: on the ribbon sheet, below
+  // the medal sheet's first row. Absence and out-of-range must read alike.
+  r = validateManifest(
+    [{ name: "Lifetime Medal", ribbon: "ribbon.png", medal: "medal.png" }],
+    CATALOG,
+    dir,
+  );
+  ok(
+    "validate: a medal source for a below-minimum medalPriority errors",
+    r.errors.some((e) => e.includes("medal sheet") && e.includes("below")),
+  );
+
+  // The mirror. An award can be medal-only if it omits awardPriority, so the
+  // same contradiction has a ribbon-side shape that must fail identically.
+  r = validateManifest(
+    [{ name: "Medal Only", ribbon: "ribbon.png", medal: "medal.png" }],
+    indexCatalog([
+      { name: "Medal Only", medalPriority: 5, awardType: "Medal" },
+    ]),
+    dir,
+  );
+  ok(
+    "validate: a ribbon source for a medal-only award errors (the mirror case)",
+    r.errors.some(
+      (e) => e.includes("ribbon sheet") && e.includes("no awardPriority"),
+    ),
   );
 
   r = validateManifest(
@@ -474,6 +557,48 @@ async function main() {
   ok(
     "validate: two replaces on the same sheet (no insert) is allowed",
     !r.errors.some((e) => e.includes("both a replace and an insert")),
+  );
+
+  // An unrecognised key is rejected rather than ignored. `replace` is read as a
+  // strict `=== true`, so a near-miss spelling reads as absent and downgrades a
+  // replace to an insert — which shifts every row below it, silently.
+  r = validateManifest(
+    [{ name: "Foo Ribbon", ribbon: "ribbon.png", replaced: true }],
+    CATALOG,
+    dir,
+  );
+  ok(
+    'validate: a near-miss "replace" key errors instead of reading as an insert',
+    r.errors.some(
+      (e) => e.includes("unrecognised key") && e.includes("replaced"),
+    ),
+  );
+
+  r = validateManifest(
+    [{ name: "Foo Ribbon", ribbon: "ribbon.png", note: "hi" }],
+    CATALOG,
+    dir,
+  );
+  ok(
+    "validate: any unrecognised key errors, not only near-misses of a real one",
+    r.errors.some((e) => e.includes("unrecognised key")),
+  );
+
+  r = validateManifest(
+    [
+      {
+        name: "Bar Medal",
+        ribbon: "ribbon.png",
+        medal: "medal.png",
+        replace: true,
+      },
+    ],
+    CATALOG,
+    dir,
+  );
+  ok(
+    "validate: all four allowed keys together still pass",
+    r.errors.length === 0,
   );
 
   // --- spliceSheet: two new tiles interleave at their final catalog rows ---
@@ -831,7 +956,75 @@ async function main() {
     (await sharp(paths.medalSheet).metadata()).height === medHR,
   );
 
-  // --- run: an ignored extra source is NOT deleted (only placed tiles) ---
+  // --- run: a typo'd replace key aborts instead of turning into an insert ---
+  // The damaging shape: the operator asked to overwrite one tile, and a single
+  // misspelled key would instead insert on BOTH sheets, pushing every award
+  // below down one row so each renders as its neighbour — with no diagnostic.
+  await makeSheet(paths.ribbonSheet, 43, 14, [
+    [1, 0, 0],
+    [2, 0, 0],
+    [3, 0, 0],
+  ]);
+  await makeSheet(paths.medalSheet, 70, 120, [
+    [0, 1, 0],
+    [0, 2, 0],
+  ]);
+  fs.writeFileSync(
+    path.join(dir, "rT.png"),
+    await colorTile(43, 13, [6, 6, 6]),
+  );
+  fs.writeFileSync(
+    path.join(dir, "mT.png"),
+    await colorTile(72, 148, [6, 6, 6]),
+  );
+  fs.writeFileSync(
+    paths.manifest,
+    JSON.stringify(
+      [
+        {
+          name: "Bar Medal",
+          ribbon: "rT.png",
+          medal: "mT.png",
+          replaced: true,
+        },
+      ],
+      null,
+      2,
+    ) + "\n",
+  );
+  const ribHT = (await sharp(paths.ribbonSheet).metadata()).height;
+  const medHT = (await sharp(paths.medalSheet).metadata()).height;
+  let typoThrew = false;
+  try {
+    await run(paths, silent());
+  } catch (e) {
+    typoThrew = true;
+  }
+  ok("run(typo): unrecognised key aborts the run", typoThrew);
+  ok(
+    "run(typo): ribbon sheet not grown by a mistaken insert",
+    (await sharp(paths.ribbonSheet).metadata()).height === ribHT,
+  );
+  ok(
+    "run(typo): medal sheet not grown by a mistaken insert",
+    (await sharp(paths.medalSheet).metadata()).height === medHT,
+  );
+  ok(
+    "run(typo): sources kept for a retry, not consumed",
+    fs.existsSync(path.join(dir, "rT.png")) &&
+      fs.existsSync(path.join(dir, "mT.png")),
+  );
+  ok(
+    "run(typo): manifest entry retained, not emptied",
+    JSON.parse(fs.readFileSync(paths.manifest, "utf8")).length === 1,
+  );
+
+  // --- run: a source for a non-member sheet aborts, consuming nothing ---
+  // The whole danger of this tool is that it deletes its inputs and CI opens a
+  // PR on success, so a run that places one of two tiles and still exits 0
+  // destroys the evidence that anything was missed. Assert at the run() seam,
+  // not just validateManifest: the error is only worth anything if it actually
+  // reaches the caller before a sheet is written or a source is unlinked.
   await makeSheet(paths.ribbonSheet, 43, 14, [
     [1, 0, 0],
     [2, 0, 0],
@@ -853,14 +1046,26 @@ async function main() {
       2,
     ) + "\n",
   );
-  await run(paths, silent());
+  const ribGuardHalf = fs.readFileSync(paths.ribbonSheet);
+  let halfThrew = false;
+  try {
+    await run(paths, silent());
+  } catch (e) {
+    halfThrew = true;
+  }
+  ok("run(half-placed): a source for a non-member sheet aborts", halfThrew);
   ok(
-    "run: placed ribbon source removed",
-    !fs.existsSync(path.join(dir, "rib3.png")),
+    "run(half-placed): the placeable ribbon tile was not spliced in anyway",
+    ribGuardHalf.equals(fs.readFileSync(paths.ribbonSheet)),
   );
   ok(
-    "run: ignored extra (unplaced) source is kept, not deleted",
-    fs.existsSync(path.join(dir, "extra.png")),
+    "run(half-placed): both sources kept for a retry",
+    fs.existsSync(path.join(dir, "rib3.png")) &&
+      fs.existsSync(path.join(dir, "extra.png")),
+  );
+  ok(
+    "run(half-placed): manifest entry retained, not emptied",
+    JSON.parse(fs.readFileSync(paths.manifest, "utf8")).length === 1,
   );
 
   fs.rmSync(dir, { recursive: true, force: true });

--- a/generateAwardSprites.test.js
+++ b/generateAwardSprites.test.js
@@ -205,18 +205,6 @@ async function main() {
     true,
   );
 
-  // Every medal-sheet type is also a ribbon-sheet type. sheetExclusionReason
-  // leans on this to answer the ribbon side with a single fixed reason: an
-  // award reaching it is always a medal-sheet member, so its awardType is
-  // necessarily a ribbon type and only the priority can be missing. Add a type
-  // to MEDAL_SHEET_TYPES alone and that reason silently becomes a wrong
-  // diagnosis rather than a failure, so pin the premise here.
-  const medalTypesOffRibbonSheet = [...MEDAL_SHEET_TYPES].filter(
-    (t) => !RIBBON_SHEET_TYPES.has(t),
-  );
-  assert.deepStrictEqual(medalTypesOffRibbonSheet, []);
-  ok("membership: every medal-sheet type is also a ribbon-sheet type", true);
-
   // --- indexCatalog / lookupAward ---
   assert.deepStrictEqual(lookupAward(CATALOG, "Foo Ribbon"), {
     name: "Foo Ribbon",
@@ -476,7 +464,12 @@ async function main() {
   );
   ok(
     "validate: a medal source for a ribbon carrying a medalPriority errors",
-    r.errors.some((e) => e.includes("medal sheet") && e.includes("awardType")),
+    r.errors.some(
+      (e) =>
+        e.includes("medal sheet") &&
+        e.includes('awardType "Ribbon"') &&
+        !e.includes("medalPriority"),
+    ),
   );
 
   // Priorities 0 and 1 are the two Lifetime medals: on the ribbon sheet, below
@@ -1066,6 +1059,97 @@ async function main() {
   ok(
     "run(half-placed): manifest entry retained, not emptied",
     JSON.parse(fs.readFileSync(paths.manifest, "utf8")).length === 1,
+  );
+
+  // --- run: one bad entry aborts the whole manifest, not just itself ---
+  // Validation runs over every entry before any splice, so a good entry sharing
+  // the manifest with a bad one must not be half-applied. Pinned at the run()
+  // seam because that is the property worth keeping if entry handling ever
+  // moves closer to per-entry processing: partial application is what makes
+  // this tool dangerous, since the sources that prove it are deleted.
+  await makeSheet(paths.ribbonSheet, 43, 14, [
+    [1, 0, 0],
+    [2, 0, 0],
+    [3, 0, 0],
+  ]);
+  await makeSheet(paths.medalSheet, 70, 120, [[0, 1, 0]]);
+  fs.writeFileSync(
+    path.join(dir, "good.png"),
+    await colorTile(43, 13, [5, 5, 5]),
+  );
+  fs.writeFileSync(
+    path.join(dir, "bad.png"),
+    await colorTile(43, 13, [4, 4, 4]),
+  );
+  fs.writeFileSync(
+    path.join(dir, "badMedal.png"),
+    await colorTile(72, 148, [4, 4, 4]),
+  );
+  fs.writeFileSync(
+    paths.manifest,
+    JSON.stringify(
+      [
+        { name: "Foo Ribbon", ribbon: "good.png" },
+        // Lifetime Medal is medalPriority 0, so it has no medal tile.
+        { name: "Lifetime Medal", ribbon: "bad.png", medal: "badMedal.png" },
+      ],
+      null,
+      2,
+    ) + "\n",
+  );
+  const ribGuardMulti = fs.readFileSync(paths.ribbonSheet);
+  let multiThrew = false;
+  try {
+    await run(paths, silent());
+  } catch (e) {
+    multiThrew = true;
+  }
+  ok("run(multi): one bad entry aborts the run", multiThrew);
+  ok(
+    "run(multi): the good entry's tile was not spliced in",
+    ribGuardMulti.equals(fs.readFileSync(paths.ribbonSheet)),
+  );
+  ok(
+    "run(multi): the good entry's source is not consumed",
+    fs.existsSync(path.join(dir, "good.png")),
+  );
+  ok(
+    "run(multi): both manifest entries retained",
+    JSON.parse(fs.readFileSync(paths.manifest, "utf8")).length === 2,
+  );
+
+  // --- run: normalizer warnings still reach the caller and the log ---
+  // validateManifest no longer produces warnings, so this is the only path that
+  // fills the channel. Left unexercised it would rot silently.
+  await makeSheet(paths.ribbonSheet, 43, 14, [
+    [1, 0, 0],
+    [2, 0, 0],
+    [3, 0, 0],
+  ]);
+  fs.writeFileSync(
+    path.join(dir, "odd.png"),
+    await colorTile(40, 20, [3, 3, 3]),
+  );
+  fs.writeFileSync(
+    paths.manifest,
+    JSON.stringify([{ name: "Foo Ribbon", ribbon: "odd.png" }], null, 2) + "\n",
+  );
+  const warned = [];
+  const spy = {
+    log() {},
+    warn(m) {
+      warned.push(m);
+    },
+    error() {},
+  };
+  const oddResult = await run(paths, spy);
+  ok(
+    "run(warnings): an off-size source is reported, not silently reshaped",
+    oddResult.warnings.some((w) => w.includes("40x20")),
+  );
+  ok(
+    "run(warnings): the warning reaches the log too",
+    warned.some((w) => w.includes("40x20")),
   );
 
   fs.rmSync(dir, { recursive: true, force: true });

--- a/uniform-uploads/README.md
+++ b/uniform-uploads/README.md
@@ -30,9 +30,10 @@ the sprite sheets and opens a pull request for review.
 
    - `name` must match the catalog award name exactly.
    - `name`, `ribbon`, `medal` and `replace` are the only keys an entry may
-     carry. Anything else fails the run, because a misspelled `replace` would
-     otherwise read as absent and insert a duplicate tile instead of
-     overwriting one.
+     carry, and the error message lists them if you get one wrong. Anything
+     else fails the run: a misspelled `replace` would otherwise read as absent,
+     inserting a tile instead of overwriting one and pushing every award below
+     it down a row.
    - Supply `ribbon` if the award has an `awardPriority`, and `medal` if it has
      a `medalPriority` of 2 or higher. Service ribbons have both; pure ribbons
      have only `ribbon`. Priorities 0 and 1 are the two Lifetime medals, which

--- a/uniform-uploads/README.md
+++ b/uniform-uploads/README.md
@@ -29,10 +29,18 @@ the sprite sheets and opens a pull request for review.
    ```
 
    - `name` must match the catalog award name exactly.
+   - `name`, `ribbon`, `medal` and `replace` are the only keys an entry may
+     carry. Anything else fails the run, because a misspelled `replace` would
+     otherwise read as absent and insert a duplicate tile instead of
+     overwriting one.
    - Supply `ribbon` if the award has an `awardPriority`, and `medal` if it has
      a `medalPriority` of 2 or higher. Service ribbons have both; pure ribbons
      have only `ribbon`. Priorities 0 and 1 are the two Lifetime medals, which
      sit on the ribbon sheet only.
+   - Supplying art for a sheet the catalog does not place the award on fails
+     the run rather than skipping that tile. If you meant to add the tile, the
+     catalog entry is what needs fixing; if you did not, drop the key. Either
+     way nothing is spliced and your PNGs stay put for the retry.
    - Only mainline medals and ribbons live in these two sheets. Badges, tabs,
      weapon quals and unit citations render from separate assets and cannot be
      uploaded here, even though they carry an `awardPriority`.


### PR DESCRIPTION
## What

Two silent-failure bugs from #139. Both were found while reviewing #177 and deliberately left out of it to keep that branch focused. Both let a bad manifest entry consume its source art, empty the manifest, and exit 0.

## The failure mode

The generator deletes the contributor's source PNGs and empties `manifest.json` on success, and `award_sprites.yml` opens a PR from that. A run that does only part of the work and still exits 0 is therefore much worse than a crash: the inputs that would prove something was skipped are already gone, and the reviewer sees a clean-looking PR full of regenerated binary sheets.

## Bug 1: a placement field omitted from the catalog, with art supplied anyway

`validateManifest` warned when the manifest supplied a source for a sheet the catalog does not place that award on, then carried on. Reproduced with a synthetic catalog and sheets:

```
catalog:  { name: "New Medal", awardPriority: 2, awardType: "Medal" }   // medalPriority forgotten
manifest: { name: "New Medal", ribbon: "r.png", medal: "m.png" }

exit code:       0
warnings:        WARN: entry 0: "New Medal" does not belong to the medal sheet; ignoring its "medal" source
ribbon sheet:    70 -> 84      (inserted)
medal sheet:     600 -> 600    (never placed)
ribbon art kept: false         (DELETED)
manifest now:    []            (EMPTIED)
```

The warning reads as "correct, this is a ribbon-only award", not "you forgot `medalPriority`". The ribbons render fine in review and nobody goes looking for the missing medal.

This cannot be fixed in `malformedFields`. Omitting `medalPriority` is the legitimate way to express a ribbon-only award, and 9 awards in the real catalog do exactly that, so absence on its own cannot be an error. The disambiguating signal is that the manifest supplies `medal:`, a human asserting the award has medal art. That signal was being discarded.

It is now an error naming the sheet, why the award is not on it, and both ways out. The same shape covers a `medalPriority` of 0 or 1 (below the sheet's first row), a non-medal `awardType` carrying a `medalPriority`, and the mirror case of a ribbon source on a medal-only award.

## Bug 2: an unrecognised manifest key turns a replace into an insert

`replace` was type-checked if present, but unknown keys were never rejected, and `entry.replace === true` is a strict identity read, so any near-miss spelling silently meant insert. Against the real catalog and copies of the production sheets:

| manifest key | ribbon sheet | medal sheet | warnings | exit |
|---|---|---|---|---|
| `"replace": true` (correct) | 783 | 5401 | none | 0 |
| `"replaced": true` (typo) | **797** | **5521** | **none** | 0 |

One typo, and 67 ribbon awards and 44 medal awards render as their neighbour. Unrecognised keys are now rejected with the allowed set listed in the message.

## Notes

`validateManifest` no longer returns a `warnings` array. Once every condition became an error it was always empty, and a warning is worth little in this tool anyway: by the time anyone reads it, the sources that would prove something was skipped are deleted. `run()` still collects the normalizers' geometry warnings.

The second commit closes gaps from a review of the first. `sheetExclusionReason` was answering the ribbon side without reading the award, correct only via two caller-side facts invisible from inside it; it now checks type before priority on both sides. Two comments the first commit rotted are corrected, and two over-claims are walked back.

## Verification

- 97 assertions pass (was 77). Prettier passes.
- Both bugs are pinned at the `validateManifest` seam and the `run()` seam, the latter asserting observable sheet heights, byte-equality, filesystem effects and manifest contents.
- All 20 regression assertions were confirmed to fail against `main`, so none of them is a test without teeth.
- A manifest holding one good entry and one bad one aborts whole, with the good entry's tile unspliced and its source still on disk.
- Run against copies of the production sheets: a correct `replace` holds 783 / 5401, and both bug shapes now abort instead of writing.

## Found in review, deliberately not fixed here

**An omitted `replace` does the same damage as the misspelled one.** Nothing checks whether the target row is already occupied, so a contributor re-uploading fixed art who simply forgets the flag gets a silent insert:

```
WITH    "replace": true  -> ribbon 783, medal 5401   (correct)
WITHOUT "replace"        -> ribbon 797, medal 5521   exit 0, diagnostics NONE, art deleted
```

This PR does not introduce it and does not fix it. It is reachable through the documented happy path, with no typo and no catalog mistake required, which arguably makes it worse than either bug above. Fixing it needs an occupancy check against the catalog-derived extent, plus a decision on whether `replace` should stop being optional. One trap for whoever takes it: both production sheets carry a sub-tile remainder (783 = 55*14 + 13, 5401 = 45*120 + 1), so an exact height-multiple invariant false-positives on both.

Three smaller pre-existing items are also untouched: the top-level handler discarding the stack, `award_sprites.yml` inferring success from `git status` rather than the generator's own count, and a stale `getMaxAwardCount` reference in `awardAttachmentTypes.js`.

> *This was generated by AI*
