### PR TITLE
chore(ci): add CODEOWNERS and Dependabot auto-merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Review routing only — the branch ruleset does not require code-owner review.
+# Everyone listed here must hold write permission or the entry is silently a
+# no-op. Keep that in mind before adding anyone.
+* @SyniRon @Vercin-G

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# Dependabot-triggered runs get a read-only GITHUB_TOKEN no matter what the
+# repository default is, so the merge step below fails on permissions without
+# this block.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+
+      # Majors land as individual PRs (see dependabot.yml) so they get looked at
+      # on their own; the grouped minor/patch PRs are what this arms. Auto-merge
+      # only fires once the required status checks pass, so this is not a way
+      # around CI.
+      - name: Arm auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Second half of the branch-protection rollout. The rulesets are already live; this PR is the vehicle for observing a real PR pass through them before classic protection is removed.

- `.github/CODEOWNERS` — routing only. Both owners hold write permission. `require_code_owner_review` stays **off** in the ruleset.
- `.github/workflows/dependabot_auto_merge.yml` — arms GitHub auto-merge on non-major Dependabot PRs.

### This does not weaken CI

Required status checks (`lint_format_check`) live in the `default-branch` ruleset, which has **no bypass actors**. Dependabot bypasses only the separate approval ruleset. Every merge still passes CI.

### Trade-off, stated plainly

`dependabot.yml` uses a 7-day cooldown so version bumps wait for supply-chain flagging before reaching the review queue. With auto-merge on, non-major bumps no longer reach a review queue at all — the cooldown becomes the control rather than a delay before human eyes. This was a deliberate call. Major bumps still land as individual PRs requiring approval.

### Verification limit

A human-authored PR only proves the actor gate and that the workflow parses — the `automerge` job shows as skipped here. The merge step and the `permissions:` block are not exercised until a real Dependabot PR runs.

> *This was generated by AI*