### PR TITLE
fix(ci): open sprite PRs with an App token, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/award_sprites.yml
+++ b/.github/workflows/award_sprites.yml
@@ -123,10 +123,26 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         run: npm run format:check
 
+      # The PR below MUST NOT be opened with the default GITHUB_TOKEN. Events
+      # triggered by that token do not start workflow runs, so LINT_FORMAT_CHECK
+      # would never report on the PR — and `main` requires that check, which
+      # would leave every sprite PR permanently unmergeable. An App
+      # installation token is an ordinary actor, so the push and the PR fire
+      # workflows normally. Minted only when there is a PR to open; revoked
+      # automatically when the job ends.
+      - name: Mint sprite-bot token
+        id: app-token
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ secrets.SPRITE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SPRITE_BOT_PRIVATE_KEY }}
+
       - name: Open pull request
         if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: award-sprites/${{ github.ref_name }}
           base: ${{ github.ref_name }}
           add-paths: |


### PR DESCRIPTION
Completes the branch-protection rollout. Depends on the `SPRITE_BOT_CLIENT_ID` / `SPRITE_BOT_PRIVATE_KEY` secrets, which are already set.

## Why

`main` now requires the `LINT_FORMAT_CHECK` context. Events triggered by the default `GITHUB_TOKEN` do not start workflow runs, so a sprite PR opened with it would never receive that check and the ruleset would block it permanently. No sprite PR has ever been created, so nothing is broken today — the first one would have been.

An App installation token is an ordinary actor, so both the branch push and the PR fire workflows normally.

## The App

`7cav-sprite-bot`, org-owned, installed on selected repositories. Permissions are exactly `contents: write`, `pull_requests: write`, `metadata: read` — no Workflows scope, since these PRs only touch `client/public/skunkworks/**` and `uniform-uploads/**`. The token is minted only when there is a PR to open and is revoked when the job ends.

## `branches-ignore` is now load-bearing

It used to be decorative — `GITHUB_TOKEN` pushes never triggered anything. Now those pushes do trigger workflows, and the sprite PR touches `uniform-uploads/**`, which is this workflow's own path filter. `branches-ignore: award-sprites/**` is the only thing preventing self-retrigger. Do not remove it.

## Not verified yet

The workflow has never run end to end. This change is exercised only when someone pushes art to `uniform-uploads/**`. Specifically unproven: that the App token has access to this repo (I could not confirm the installation's repository list via API — it needs App or PAT auth), and that `LINT_FORMAT_CHECK` does report on the resulting PR. Both show up on the first real sprite run.

Sprite PRs will also need one human approval — the App is not a ruleset bypass actor, only Dependabot is.

> *This was generated by AI*