### PR TITLE
chore: finish the CavApps rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-[![Production Deployment](https://github.com/7Cav/adr/actions/workflows/prod_deploy.yml/badge.svg)](https://apps.7cav.us/)
-[![Development Deployment](https://github.com/7Cav/adr/actions/workflows/dev_deploy.yml/badge.svg)](https://beta.apps.7cav.us/)
+[![Production Deployment](https://github.com/7Cav/CavApps/actions/workflows/prod_deploy.yml/badge.svg)](https://apps.7cav.us/)
+[![Development Deployment](https://github.com/7Cav/CavApps/actions/workflows/dev_deploy.yml/badge.svg)](https://beta.apps.7cav.us/)
 
-7th Cavalry Apps (CavApps) is a Nextjs based collection of tools and apps designed to aid the 7th Cavalry Gaming Regiment in its day to day functions. It currently includes the Active Duty Roster (ADR) and a small collection of Roster Statistics. Future iterations could include a more advanced statistics tool, an AWOL tracker, and a migration of S1 Documents, among other possible tools. CavApps uses a Frontend-Backend architecture and includes basic authentication.
+7th Cavalry Apps (CavApps) is a Nextjs based collection of tools and apps designed to aid the 7th Cavalry Gaming Regiment in its day to day functions. It currently includes the Active Duty Roster (ADR), a small collection of Roster Statistics, and the Uniform Builder. Future iterations could include a more advanced statistics tool, an AWOL tracker, and a migration of S1 Documents, among other possible tools. CavApps uses a Frontend-Backend architecture and includes basic authentication.
 
 The live deployment can be found at https://apps.7cav.us/ and the backend at https://bff.apps.7cav.us/
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "adr",
+  "name": "cavapps",
   "private": true,
   "scripts": {
     "format:check": "prettier --check \"{**/*,*}.{js,jsx,json,html,css}\"",


### PR DESCRIPTION
The repo slug moved from `adr` to `CavApps`. This catches the last in-repo references to the old name.

## Why

The rest of the repo already called itself CavApps — the logo, the README prose, `client/package.json` (`cavapps`), `server/package.json` (`cavapps-server`), and every `container_name` and network in `docker-compose.yml`. The root `package.json` and the two workflow badge URLs were the only holdouts.

## Changes

- `package.json` — `"name": "adr"` → `"cavapps"`, matching `client/`
- `README.md` — both CI badge URLs → `7Cav/CavApps`
- `README.md` — the overview paragraph now lists the Uniform Builder. It was already documented further down as one of the client's three tools; only the summary at the top was stale. **Unrelated to the rename — say the word and I'll drop it.**

## Deploys are unaffected

Nothing under `.github/` references the repo name in any form — no `github.repository`, no `repository:` on any checkout. Both deploy workflows use bare `actions/checkout` (implicitly the current repo) and push to hardcoded Docker Hub tags `7cav/apps_client` / `7cav/apps_server`, which live in a separate namespace. Watchtower is pinged by URL and pulls by image tag. Repo secrets, branch protection, and the sprite-bot App installation are all keyed to the repo ID, which a rename preserves.

## Related

The archived 2018 Laravel repo that held this name is now [`7Cav/cavapps-legacy`](https://github.com/7Cav/cavapps-legacy).

> *This was generated by AI*