### PR TITLE
Feat/medal rec validation feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Create `client/.env.local` with:
 NEXT_PUBLIC_CLIENT_TOKEN=any-shared-secret-you-choose
 COMBAT_API_URL=http://localhost:4000/roster/combat
 RESERVE_API_URL=http://localhost:4000/roster/reserves
+MEDAL_RECIPIENT_API_URL=http://localhost:4000/roster/medal-recipients
 GROUP_API_URL=http://localhost:4000/roster/groups
 CACHE_TIMESTAMP_URL=http://localhost:4000/cache-timestamp
 NEXT_PUBLIC_INDIVIDUAL_API_URL=http://localhost:4000/roster/individual

--- a/client/app/medalrecommendation/MedalRecommendationClient.jsx
+++ b/client/app/medalrecommendation/MedalRecommendationClient.jsx
@@ -358,7 +358,13 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
               Action Character
             </label>
 
-            <Select value={actionCharacter} onValueChange={setActionCharacter}>
+            <Select
+              value={actionCharacter}
+              onValueChange={(value) => {
+                setActionCharacter(value);
+                setRecommendation(null);
+              }}
+            >
               <SelectTrigger
                 id="action-character"
                 aria-invalid={actionCharacterIsInvalid ? "true" : undefined}
@@ -411,7 +417,10 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                   ? "border-destructive focus-visible:ring-destructive"
                   : undefined
               }
-              onChange={(event) => setCombatElement(event.target.value)}
+              onChange={(event) => {
+                setCombatElement(event.target.value);
+                setRecommendation(null);
+              }}
             />
 
             {combatElementIsInvalid && (
@@ -442,7 +451,10 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                   ? "border-destructive focus-visible:ring-destructive"
                   : undefined
               }
-              onChange={(event) => setOperationTitle(event.target.value)}
+              onChange={(event) => {
+                setOperationTitle(event.target.value);
+                setRecommendation(null);
+              }}
             />
 
             {operationTitleIsInvalid && (
@@ -473,7 +485,10 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                   ? "border-destructive focus-visible:ring-destructive"
                   : undefined
               }
-              onChange={(event) => setLocation(event.target.value)}
+              onChange={(event) => {
+                setLocation(event.target.value);
+                setRecommendation(null);
+              }}
             />
 
             {locationIsInvalid && (
@@ -504,7 +519,10 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                   ? "border-destructive focus-visible:ring-destructive"
                   : undefined
               }
-              onChange={(event) => setOperationDate(event.target.value)}
+              onChange={(event) => {
+                setOperationDate(event.target.value);
+                setRecommendation(null);
+              }}
             />
 
             {operationDateIsInvalid && (
@@ -533,7 +551,10 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                     ? "narrative-warnings"
                     : undefined
               }
-              onChange={(event) => setNarrative(event.target.value)}
+              onChange={(event) => {
+                setNarrative(event.target.value);
+                setRecommendation(null);
+              }}
               rows={8}
               className={`flex w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                 narrativeIsInvalid

--- a/client/app/medalrecommendation/MedalRecommendationClient.jsx
+++ b/client/app/medalrecommendation/MedalRecommendationClient.jsx
@@ -41,15 +41,63 @@ function getCitationName(fullName) {
   return `${nameParts[0]} ${nameParts[nameParts.length - 1]}`;
 }
 
-function normalizeFirstRecipientMention(narrative, recipient) {
+function getRankEntries(rosterMembers) {
+  const rankEntriesByShortName = new Map();
+
+  for (const member of rosterMembers) {
+    const rankShort = member?.rank?.rankShort?.trim() ?? "";
+    const rankFull = member?.rank?.rankFull?.trim() ?? "";
+
+    if (
+      !rankShort ||
+      !rankFull ||
+      rankShort.toLowerCase() === rankFull.toLowerCase()
+    ) {
+      continue;
+    }
+
+    const key = rankShort.toLowerCase();
+
+    if (!rankEntriesByShortName.has(key)) {
+      rankEntriesByShortName.set(key, {
+        short: rankShort,
+        full: rankFull,
+      });
+    }
+  }
+
+  return Array.from(rankEntriesByShortName.values()).sort(
+    (a, b) => b.short.length - a.short.length,
+  );
+}
+
+function isBareLastNameInsideAnotherName(text, matchIndex) {
+  const precedingText = text.slice(0, matchIndex);
+  const precedingTokenMatch = precedingText.match(
+    /([A-Za-z][A-Za-z.'’\-]*)\s+$/,
+  );
+
+  if (!precedingTokenMatch) {
+    return false;
+  }
+
+  const precedingToken = precedingTokenMatch[1];
+
+  return /[A-Z]/.test(precedingToken);
+}
+
+function normalizeNarrativeFormatting(narrative, recipient, rankEntries) {
   const text = narrative.trim();
 
-  const rankFull = recipient?.rank?.rankFull?.trim() ?? "";
-  const rankShort = recipient?.rank?.rankShort?.trim() ?? "";
+  const recipientRankFull = recipient?.rank?.rankFull?.trim() ?? "";
+  const recipientRankShort = recipient?.rank?.rankShort?.trim() ?? "";
   const rosterFullName = recipient?.realName?.trim() ?? "";
 
-  if (!rankFull || !rosterFullName) {
-    return text;
+  if (!recipientRankFull || !rosterFullName) {
+    return {
+      segments: [{ text, adjusted: false }],
+      hasAdjustments: false,
+    };
   }
 
   const citationName = getCitationName(rosterFullName);
@@ -57,43 +105,174 @@ function normalizeFirstRecipientMention(narrative, recipient) {
   const lastName = nameParts[nameParts.length - 1];
 
   if (!citationName || !lastName) {
-    return text;
+    return {
+      segments: [{ text, adjusted: false }],
+      hasAdjustments: false,
+    };
   }
 
-  const normalizedIdentity = `${rankFull} ${citationName}`;
-
-  const possibleMentions = [
-    `${escapeRegExp(rankFull)}\\s+${escapeRegExp(rosterFullName)}`,
-    `${escapeRegExp(rankFull)}\\s+${escapeRegExp(citationName)}`,
-    `${escapeRegExp(rankFull)}\\s+${escapeRegExp(lastName)}`,
-    rankShort
-      ? `${escapeRegExp(rankShort)}\\.?\\s+${escapeRegExp(rosterFullName)}`
+  const possibleRecipientMentions = [
+    `${escapeRegExp(recipientRankFull)}\\s+${escapeRegExp(rosterFullName)}`,
+    `${escapeRegExp(recipientRankFull)}\\s+${escapeRegExp(citationName)}`,
+    `${escapeRegExp(recipientRankFull)}\\s+${escapeRegExp(lastName)}`,
+    recipientRankShort
+      ? `${escapeRegExp(recipientRankShort)}\\.?\\s+${escapeRegExp(rosterFullName)}`
       : "",
-    rankShort
-      ? `${escapeRegExp(rankShort)}\\.?\\s+${escapeRegExp(citationName)}`
+    recipientRankShort
+      ? `${escapeRegExp(recipientRankShort)}\\.?\\s+${escapeRegExp(citationName)}`
       : "",
-    rankShort
-      ? `${escapeRegExp(rankShort)}\\.?\\s+${escapeRegExp(lastName)}`
+    recipientRankShort
+      ? `${escapeRegExp(recipientRankShort)}\\.?\\s+${escapeRegExp(lastName)}`
       : "",
     escapeRegExp(rosterFullName),
     escapeRegExp(citationName),
+    escapeRegExp(lastName),
   ]
     .filter(Boolean)
     .filter((value, index, values) => values.indexOf(value) === index)
     .sort((a, b) => b.length - a.length);
 
-  const firstMentionPattern = new RegExp(
-    `(^|[^A-Za-z0-9])(?:${possibleMentions.join("|")})(?=$|[^A-Za-z0-9])`,
-    "i",
+  const rankShortPattern = rankEntries
+    .map((rankEntry) => escapeRegExp(rankEntry.short))
+    .join("|");
+
+  const otherTrooperRankPattern = rankShortPattern
+    ? `(?:${rankShortPattern})\\.?\\s+(?:[A-Za-z]\\.|[A-Za-z][A-Za-z'’\\-]*)`
+    : "(?!)";
+
+  const combinedPattern = new RegExp(
+    `(^|[^A-Za-z0-9])(?:(${possibleRecipientMentions.join("|")})|(${otherTrooperRankPattern}))(?=$|[^A-Za-z0-9])`,
+    "gi",
   );
 
-  return text.replace(
-    firstMentionPattern,
-    (_match, prefix) => `${prefix}${normalizedIdentity}`,
+  const segments = [];
+  let cursor = 0;
+  let recipientMentionCount = 0;
+
+  for (const match of text.matchAll(combinedPattern)) {
+    const prefix = match[1] ?? "";
+    const originalText = match[2] ?? match[3] ?? "";
+    const matchIndex = (match.index ?? 0) + prefix.length;
+
+    if (matchIndex > cursor) {
+      segments.push({
+        text: text.slice(cursor, matchIndex),
+        adjusted: false,
+      });
+    }
+
+    if (match[2] !== undefined) {
+      const isBareLastName =
+        originalText.toLowerCase() === lastName.toLowerCase();
+
+      const shouldPreserveBareLastName =
+        isBareLastName &&
+        (originalText !== lastName ||
+          isBareLastNameInsideAnotherName(text, matchIndex));
+
+      if (shouldPreserveBareLastName) {
+        segments.push({
+          text: originalText,
+          adjusted: false,
+        });
+
+        cursor = matchIndex + originalText.length;
+        continue;
+      }
+
+      const replacement =
+        recipientMentionCount === 0
+          ? `${recipientRankFull} ${citationName}`
+          : `${recipientRankFull} ${lastName}`;
+
+      recipientMentionCount += 1;
+
+      segments.push({
+        text: replacement,
+        adjusted: originalText !== replacement,
+      });
+    } else {
+      const rankEntry = rankEntries.find((entry) => {
+        const rankPrefixPattern = new RegExp(
+          `^${escapeRegExp(entry.short)}\\.?\\s`,
+          "i",
+        );
+
+        return rankPrefixPattern.test(originalText);
+      });
+
+      if (!rankEntry) {
+        segments.push({
+          text: originalText,
+          adjusted: false,
+        });
+      } else {
+        const rankPrefixPattern = new RegExp(
+          `^${escapeRegExp(rankEntry.short)}\\.?`,
+          "i",
+        );
+
+        const replacement = originalText.replace(
+          rankPrefixPattern,
+          rankEntry.full,
+        );
+
+        segments.push({
+          text: replacement,
+          adjusted: replacement !== originalText,
+        });
+      }
+    }
+
+    cursor = matchIndex + originalText.length;
+  }
+
+  if (cursor < text.length) {
+    segments.push({
+      text: text.slice(cursor),
+      adjusted: false,
+    });
+  }
+
+  if (segments.length === 0) {
+    segments.push({
+      text,
+      adjusted: false,
+    });
+  }
+
+  return {
+    segments,
+    hasAdjustments: segments.some((segment) => segment.adjusted),
+  };
+}
+
+function requiresEligibilityWarning(recipient) {
+  return Boolean(recipient && recipient.roster !== "ROSTER_TYPE_COMBAT");
+}
+
+function renderCitationNarrative(recommendation) {
+  return (
+    <>
+      {recommendation.openingSentence}{" "}
+      {recommendation.narrativeSegments.map((segment, index) =>
+        segment.adjusted ? (
+          <mark
+            key={`adjustment-${index}`}
+            className="rounded-sm border-b border-amber-400/50 bg-amber-400/10 px-0.5 text-inherit"
+          >
+            {segment.text}
+          </mark>
+        ) : (
+          segment.text
+        ),
+      )}{" "}
+      {recommendation.closingSentence}
+    </>
   );
 }
 
-export default function MedalRecommendationClient({ combatRoster = [] }) {
+export default function MedalRecommendationClient({ recipientRoster = [] }) {
   const [recipientQuery, setRecipientQuery] = useState("");
 
   const [selectedRecipient, setSelectedRecipient] = useState(null);
@@ -110,11 +289,16 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
 
   const [narrative, setNarrative] = useState("");
 
-  const [error, setError] = useState("");
+  const [hasAttemptedGenerate, setHasAttemptedGenerate] = useState(false);
 
   const [recommendation, setRecommendation] = useState(null);
 
-  const rosterMembers = useMemo(() => combatRoster ?? [], [combatRoster]);
+  const rosterMembers = useMemo(() => recipientRoster ?? [], [recipientRoster]);
+
+  const rankEntries = useMemo(
+    () => getRankEntries(rosterMembers),
+    [rosterMembers],
+  );
 
   const suggestions = useMemo(() => {
     const query = recipientQuery.trim().toLowerCase();
@@ -131,53 +315,81 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
       .slice(0, 10);
   }, [recipientQuery, rosterMembers, selectedRecipient]);
 
+  const recipientRank = selectedRecipient?.rank?.rankFull?.trim() ?? "";
+
+  const recipientRosterName = selectedRecipient?.realName?.trim() ?? "";
+
+  const recipientIsValid = Boolean(
+    selectedRecipient && recipientRank && recipientRosterName,
+  );
+
+  const actionCharacterIsValid = Boolean(actionCharacter);
+
+  const combatElementIsValid = Boolean(combatElement.trim());
+
+  const operationTitleIsValid = Boolean(operationTitle.trim());
+
+  const locationIsValid = Boolean(location.trim());
+
+  const operationDateIsValid = Boolean(operationDate);
+
+  const narrativeIsValid = Boolean(narrative.trim());
+
+  const isComplete =
+    recipientIsValid &&
+    actionCharacterIsValid &&
+    combatElementIsValid &&
+    operationTitleIsValid &&
+    locationIsValid &&
+    operationDateIsValid &&
+    narrativeIsValid;
+
+  const recipientIsInvalid = hasAttemptedGenerate && !recipientIsValid;
+
+  const actionCharacterIsInvalid =
+    hasAttemptedGenerate && !actionCharacterIsValid;
+
+  const combatElementIsInvalid = hasAttemptedGenerate && !combatElementIsValid;
+
+  const operationTitleIsInvalid =
+    hasAttemptedGenerate && !operationTitleIsValid;
+
+  const locationIsInvalid = hasAttemptedGenerate && !locationIsValid;
+
+  const operationDateIsInvalid = hasAttemptedGenerate && !operationDateIsValid;
+
+  const narrativeIsInvalid = hasAttemptedGenerate && !narrativeIsValid;
+
   function selectRecipient(member) {
     setSelectedRecipient(member);
     setRecipientQuery(member.user.username);
     setRecommendation(null);
-    setError("");
   }
 
   function handleRecipientQueryChange(event) {
     setRecipientQuery(event.target.value);
     setSelectedRecipient(null);
     setRecommendation(null);
-    setError("");
   }
 
   function handleGenerate() {
-    const recipientRank = selectedRecipient?.rank?.rankFull?.trim() ?? "";
-    const recipientRosterName = selectedRecipient?.realName?.trim() ?? "";
-
-    const isComplete =
-      selectedRecipient &&
-      recipientRank &&
-      recipientRosterName &&
-      actionCharacter &&
-      combatElement.trim() &&
-      operationTitle.trim() &&
-      location.trim() &&
-      operationDate &&
-      narrative.trim();
+    setHasAttemptedGenerate(true);
 
     if (!isComplete) {
       setRecommendation(null);
-
-      setError(
-        "Complete all required fields before generating a recommendation.",
-      );
-
       return;
     }
 
-    setError("");
+    setHasAttemptedGenerate(false);
 
     const recipientCitationName = getCitationName(recipientRosterName);
+
     const formattedDate = formatOperationDate(operationDate);
 
-    const normalizedNarrative = normalizeFirstRecipientMention(
+    const normalizedNarrative = normalizeNarrativeFormatting(
       narrative,
       selectedRecipient,
+      rankEntries,
     );
 
     const openingSentence =
@@ -189,15 +401,12 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
       `${recipientRank} ${recipientCitationName}'s ${actionCharacter} actions ` +
       "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
 
-    const citationNarrative = [
-      openingSentence,
-      normalizedNarrative,
-      closingSentence,
-    ].join(" ");
-
     setRecommendation({
       recipient: `${recipientRank} ${recipientCitationName}`,
-      citationNarrative,
+      openingSentence,
+      narrativeSegments: normalizedNarrative.segments,
+      closingSentence,
+      hasFormattingAdjustments: normalizedNarrative.hasAdjustments,
     });
   }
 
@@ -224,8 +433,26 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
               value={recipientQuery}
               autoComplete="off"
               placeholder="Enter a 7Cav username"
+              aria-invalid={recipientIsInvalid ? "true" : undefined}
+              aria-describedby={
+                recipientIsInvalid ? "recipient-required" : undefined
+              }
+              className={
+                recipientIsInvalid
+                  ? "border-destructive focus-visible:ring-destructive"
+                  : undefined
+              }
               onChange={handleRecipientQueryChange}
             />
+
+            {recipientIsInvalid && (
+              <p
+                id="recipient-required"
+                className="text-sm font-medium text-destructive"
+              >
+                Required
+              </p>
+            )}
 
             {suggestions.length > 0 && (
               <div className="flex flex-col gap-2">
@@ -243,13 +470,25 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
             )}
 
             {selectedRecipient && (
-              <div className="space-y-1">
-                <p>Selected recipient: {selectedRecipient.user.username}</p>
+              <div className="space-y-2">
+                <div className="space-y-1">
+                  <p>Selected recipient: {selectedRecipient.user.username}</p>
 
-                <p className="font-medium">
-                  {selectedRecipient.rank?.rankFull}{" "}
-                  {selectedRecipient.realName}
-                </p>
+                  <p className="font-medium">
+                    {selectedRecipient.rank?.rankFull}{" "}
+                    {selectedRecipient.realName}
+                  </p>
+                </div>
+
+                {requiresEligibilityWarning(selectedRecipient) && (
+                  <div
+                    role="status"
+                    className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm"
+                  >
+                    This member is not an active member, please confirm
+                    eligibility.
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -260,7 +499,20 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
             </label>
 
             <Select value={actionCharacter} onValueChange={setActionCharacter}>
-              <SelectTrigger id="action-character">
+              <SelectTrigger
+                id="action-character"
+                aria-invalid={actionCharacterIsInvalid ? "true" : undefined}
+                aria-describedby={
+                  actionCharacterIsInvalid
+                    ? "action-character-required"
+                    : undefined
+                }
+                className={
+                  actionCharacterIsInvalid
+                    ? "border-destructive focus:ring-destructive"
+                    : undefined
+                }
+              >
                 <SelectValue placeholder="Select action character" />
               </SelectTrigger>
 
@@ -270,6 +522,15 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
                 <SelectItem value="heroic">Heroic</SelectItem>
               </SelectContent>
             </Select>
+
+            {actionCharacterIsInvalid && (
+              <p
+                id="action-character-required"
+                className="text-sm font-medium text-destructive"
+              >
+                Required
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -281,8 +542,26 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
               id="combat-element"
               type="text"
               value={combatElement}
+              aria-invalid={combatElementIsInvalid ? "true" : undefined}
+              aria-describedby={
+                combatElementIsInvalid ? "combat-element-required" : undefined
+              }
+              className={
+                combatElementIsInvalid
+                  ? "border-destructive focus-visible:ring-destructive"
+                  : undefined
+              }
               onChange={(event) => setCombatElement(event.target.value)}
             />
+
+            {combatElementIsInvalid && (
+              <p
+                id="combat-element-required"
+                className="text-sm font-medium text-destructive"
+              >
+                Required
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -294,8 +573,26 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
               id="operation-title"
               type="text"
               value={operationTitle}
+              aria-invalid={operationTitleIsInvalid ? "true" : undefined}
+              aria-describedby={
+                operationTitleIsInvalid ? "operation-title-required" : undefined
+              }
+              className={
+                operationTitleIsInvalid
+                  ? "border-destructive focus-visible:ring-destructive"
+                  : undefined
+              }
               onChange={(event) => setOperationTitle(event.target.value)}
             />
+
+            {operationTitleIsInvalid && (
+              <p
+                id="operation-title-required"
+                className="text-sm font-medium text-destructive"
+              >
+                Required
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -307,8 +604,26 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
               id="location"
               type="text"
               value={location}
+              aria-invalid={locationIsInvalid ? "true" : undefined}
+              aria-describedby={
+                locationIsInvalid ? "location-required" : undefined
+              }
+              className={
+                locationIsInvalid
+                  ? "border-destructive focus-visible:ring-destructive"
+                  : undefined
+              }
               onChange={(event) => setLocation(event.target.value)}
             />
+
+            {locationIsInvalid && (
+              <p
+                id="location-required"
+                className="text-sm font-medium text-destructive"
+              >
+                Required
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -320,8 +635,26 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
               id="operation-date"
               type="date"
               value={operationDate}
+              aria-invalid={operationDateIsInvalid ? "true" : undefined}
+              aria-describedby={
+                operationDateIsInvalid ? "operation-date-required" : undefined
+              }
+              className={
+                operationDateIsInvalid
+                  ? "border-destructive focus-visible:ring-destructive"
+                  : undefined
+              }
               onChange={(event) => setOperationDate(event.target.value)}
             />
+
+            {operationDateIsInvalid && (
+              <p
+                id="operation-date-required"
+                className="text-sm font-medium text-destructive"
+              >
+                Required
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -332,19 +665,36 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
             <textarea
               id="narrative"
               value={narrative}
+              aria-invalid={narrativeIsInvalid ? "true" : undefined}
+              aria-describedby={
+                narrativeIsInvalid ? "narrative-required" : undefined
+              }
               onChange={(event) => setNarrative(event.target.value)}
               rows={8}
-              className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className={`flex w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                narrativeIsInvalid
+                  ? "border-destructive focus-visible:ring-destructive"
+                  : "border-input"
+              }`}
             />
+
+            {narrativeIsInvalid && (
+              <p
+                id="narrative-required"
+                className="text-sm font-medium text-destructive"
+              >
+                Required
+              </p>
+            )}
           </div>
 
           <Button type="button" onClick={handleGenerate}>
             Generate Recommendation
           </Button>
 
-          {error && (
+          {hasAttemptedGenerate && !isComplete && (
             <p role="alert" className="text-sm font-medium">
-              {error}
+              Complete all required fields before generating a recommendation.
             </p>
           )}
 
@@ -365,8 +715,19 @@ export default function MedalRecommendationClient({ combatRoster = [] }) {
               <p>{recommendation.recipient}</p>
 
               <p aria-label="Citation Narrative">
-                {recommendation.citationNarrative}
+                {renderCitationNarrative(recommendation)}
               </p>
+
+              {recommendation.hasFormattingAdjustments && (
+                <div
+                  role="status"
+                  aria-label="Formatting Adjustments"
+                  className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+                >
+                  Formatting adjustments were applied automatically. Review the
+                  highlighted changes before submitting.
+                </div>
+              )}
             </section>
           )}
         </CardContent>

--- a/client/app/medalrecommendation/MedalRecommendationClient.jsx
+++ b/client/app/medalrecommendation/MedalRecommendationClient.jsx
@@ -11,6 +11,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  analyzeNarrative,
+  getRankEntries,
+  mergeHighlightRanges,
+} from "./lib/narrative-validation";
 
 const ARCOM_RIBBON_URL = "https://wiki.7cav.us/images/d/dc/ARCOM.jpg";
 
@@ -27,10 +32,6 @@ function formatOperationDate(value) {
   }).format(date);
 }
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function getCitationName(fullName) {
   const nameParts = fullName.trim().split(/\s+/).filter(Boolean);
 
@@ -41,210 +42,64 @@ function getCitationName(fullName) {
   return `${nameParts[0]} ${nameParts[nameParts.length - 1]}`;
 }
 
-function getRankEntries(rosterMembers) {
-  const rankEntriesByShortName = new Map();
-
-  for (const member of rosterMembers) {
-    const rankShort = member?.rank?.rankShort?.trim() ?? "";
-    const rankFull = member?.rank?.rankFull?.trim() ?? "";
-
-    if (
-      !rankShort ||
-      !rankFull ||
-      rankShort.toLowerCase() === rankFull.toLowerCase()
-    ) {
-      continue;
-    }
-
-    const key = rankShort.toLowerCase();
-
-    if (!rankEntriesByShortName.has(key)) {
-      rankEntriesByShortName.set(key, {
-        short: rankShort,
-        full: rankFull,
-      });
-    }
-  }
-
-  return Array.from(rankEntriesByShortName.values()).sort(
-    (a, b) => b.short.length - a.short.length,
-  );
-}
-
-function isBareLastNameInsideAnotherName(text, matchIndex) {
-  const precedingText = text.slice(0, matchIndex);
-  const precedingTokenMatch = precedingText.match(
-    /([A-Za-z][A-Za-z.'’\-]*)\s+$/,
-  );
-
-  if (!precedingTokenMatch) {
+function isOperationDateValid(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     return false;
   }
 
-  const precedingToken = precedingTokenMatch[1];
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
 
-  return /[A-Z]/.test(precedingToken);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return false;
+  }
+
+  const now = new Date();
+  const localToday = [
+    String(now.getFullYear()).padStart(4, "0"),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("-");
+
+  return value <= localToday;
 }
 
-function normalizeNarrativeFormatting(narrative, recipient, rankEntries) {
-  const text = narrative.trim();
+function renderNarrativeWithHighlights(text, highlightRanges) {
+  const ranges = mergeHighlightRanges(highlightRanges);
 
-  const recipientRankFull = recipient?.rank?.rankFull?.trim() ?? "";
-  const recipientRankShort = recipient?.rank?.rankShort?.trim() ?? "";
-  const rosterFullName = recipient?.realName?.trim() ?? "";
-
-  if (!recipientRankFull || !rosterFullName) {
-    return {
-      segments: [{ text, adjusted: false }],
-      hasAdjustments: false,
-    };
+  if (ranges.length === 0) {
+    return text;
   }
 
-  const citationName = getCitationName(rosterFullName);
-  const nameParts = citationName.split(/\s+/);
-  const lastName = nameParts[nameParts.length - 1];
-
-  if (!citationName || !lastName) {
-    return {
-      segments: [{ text, adjusted: false }],
-      hasAdjustments: false,
-    };
-  }
-
-  const possibleRecipientMentions = [
-    `${escapeRegExp(recipientRankFull)}\\s+${escapeRegExp(rosterFullName)}`,
-    `${escapeRegExp(recipientRankFull)}\\s+${escapeRegExp(citationName)}`,
-    `${escapeRegExp(recipientRankFull)}\\s+${escapeRegExp(lastName)}`,
-    recipientRankShort
-      ? `${escapeRegExp(recipientRankShort)}\\.?\\s+${escapeRegExp(rosterFullName)}`
-      : "",
-    recipientRankShort
-      ? `${escapeRegExp(recipientRankShort)}\\.?\\s+${escapeRegExp(citationName)}`
-      : "",
-    recipientRankShort
-      ? `${escapeRegExp(recipientRankShort)}\\.?\\s+${escapeRegExp(lastName)}`
-      : "",
-    escapeRegExp(rosterFullName),
-    escapeRegExp(citationName),
-    escapeRegExp(lastName),
-  ]
-    .filter(Boolean)
-    .filter((value, index, values) => values.indexOf(value) === index)
-    .sort((a, b) => b.length - a.length);
-
-  const rankShortPattern = rankEntries
-    .map((rankEntry) => escapeRegExp(rankEntry.short))
-    .join("|");
-
-  const otherTrooperRankPattern = rankShortPattern
-    ? `(?:${rankShortPattern})\\.?\\s+(?:[A-Za-z]\\.|[A-Za-z][A-Za-z'’\\-]*)`
-    : "(?!)";
-
-  const combinedPattern = new RegExp(
-    `(^|[^A-Za-z0-9])(?:(${possibleRecipientMentions.join("|")})|(${otherTrooperRankPattern}))(?=$|[^A-Za-z0-9])`,
-    "gi",
-  );
-
-  const segments = [];
+  const parts = [];
   let cursor = 0;
-  let recipientMentionCount = 0;
 
-  for (const match of text.matchAll(combinedPattern)) {
-    const prefix = match[1] ?? "";
-    const originalText = match[2] ?? match[3] ?? "";
-    const matchIndex = (match.index ?? 0) + prefix.length;
-
-    if (matchIndex > cursor) {
-      segments.push({
-        text: text.slice(cursor, matchIndex),
-        adjusted: false,
-      });
+  for (const [index, range] of ranges.entries()) {
+    if (range.start > cursor) {
+      parts.push(text.slice(cursor, range.start));
     }
 
-    if (match[2] !== undefined) {
-      const isBareLastName =
-        originalText.toLowerCase() === lastName.toLowerCase();
+    parts.push(
+      <mark
+        key={`warning-${index}`}
+        className="rounded-sm border-b border-amber-400/50 bg-amber-400/10 px-0.5 text-inherit"
+      >
+        {text.slice(range.start, range.end)}
+      </mark>,
+    );
 
-      const shouldPreserveBareLastName =
-        isBareLastName &&
-        (originalText !== lastName ||
-          isBareLastNameInsideAnotherName(text, matchIndex));
-
-      if (shouldPreserveBareLastName) {
-        segments.push({
-          text: originalText,
-          adjusted: false,
-        });
-
-        cursor = matchIndex + originalText.length;
-        continue;
-      }
-
-      const replacement =
-        recipientMentionCount === 0
-          ? `${recipientRankFull} ${citationName}`
-          : `${recipientRankFull} ${lastName}`;
-
-      recipientMentionCount += 1;
-
-      segments.push({
-        text: replacement,
-        adjusted: originalText !== replacement,
-      });
-    } else {
-      const rankEntry = rankEntries.find((entry) => {
-        const rankPrefixPattern = new RegExp(
-          `^${escapeRegExp(entry.short)}\\.?\\s`,
-          "i",
-        );
-
-        return rankPrefixPattern.test(originalText);
-      });
-
-      if (!rankEntry) {
-        segments.push({
-          text: originalText,
-          adjusted: false,
-        });
-      } else {
-        const rankPrefixPattern = new RegExp(
-          `^${escapeRegExp(rankEntry.short)}\\.?`,
-          "i",
-        );
-
-        const replacement = originalText.replace(
-          rankPrefixPattern,
-          rankEntry.full,
-        );
-
-        segments.push({
-          text: replacement,
-          adjusted: replacement !== originalText,
-        });
-      }
-    }
-
-    cursor = matchIndex + originalText.length;
+    cursor = range.end;
   }
 
   if (cursor < text.length) {
-    segments.push({
-      text: text.slice(cursor),
-      adjusted: false,
-    });
+    parts.push(text.slice(cursor));
   }
 
-  if (segments.length === 0) {
-    segments.push({
-      text,
-      adjusted: false,
-    });
-  }
-
-  return {
-    segments,
-    hasAdjustments: segments.some((segment) => segment.adjusted),
-  };
+  return parts;
 }
 
 function requiresEligibilityWarning(recipient) {
@@ -255,17 +110,9 @@ function renderCitationNarrative(recommendation) {
   return (
     <>
       {recommendation.openingSentence}{" "}
-      {recommendation.narrativeSegments.map((segment, index) =>
-        segment.adjusted ? (
-          <mark
-            key={`adjustment-${index}`}
-            className="rounded-sm border-b border-amber-400/50 bg-amber-400/10 px-0.5 text-inherit"
-          >
-            {segment.text}
-          </mark>
-        ) : (
-          segment.text
-        ),
+      {renderNarrativeWithHighlights(
+        recommendation.narrative,
+        recommendation.highlightRanges,
       )}{" "}
       {recommendation.closingSentence}
     </>
@@ -331,7 +178,7 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
 
   const locationIsValid = Boolean(location.trim());
 
-  const operationDateIsValid = Boolean(operationDate);
+  const operationDateIsValid = isOperationDateValid(operationDate);
 
   const narrativeIsValid = Boolean(narrative.trim());
 
@@ -360,6 +207,14 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
 
   const narrativeIsInvalid = hasAttemptedGenerate && !narrativeIsValid;
 
+  const hasNarrativeWarnings = Boolean(
+    recommendation?.narrativeWarnings?.length,
+  );
+
+  const operationDateErrorMessage = operationDate
+    ? "Date must be today or earlier"
+    : "Required";
+
   function selectRecipient(member) {
     setSelectedRecipient(member);
     setRecipientQuery(member.user.username);
@@ -386,16 +241,20 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
 
     const formattedDate = formatOperationDate(operationDate);
 
-    const normalizedNarrative = normalizeNarrativeFormatting(
-      narrative,
-      selectedRecipient,
+    const normalizedOperationTitle = operationTitle
+      .trim()
+      .replace(/^operation\s+/i, "");
+
+    const narrativeAnalysis = analyzeNarrative(narrative, {
+      recipientRank,
+      recipientCitationName,
       rankEntries,
-    );
+    });
 
     const openingSentence =
       `For ${actionCharacter} actions over an entire operation while serving as ` +
       `${combatElement.trim()} in the 7th Cavalry Regiment during combat in ` +
-      `Operation ${operationTitle.trim()} near ${location.trim()} on ${formattedDate}.`;
+      `Operation ${normalizedOperationTitle} near ${location.trim()} on ${formattedDate}.`;
 
     const closingSentence =
       `${recipientRank} ${recipientCitationName}'s ${actionCharacter} actions ` +
@@ -404,9 +263,10 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
     setRecommendation({
       recipient: `${recipientRank} ${recipientCitationName}`,
       openingSentence,
-      narrativeSegments: normalizedNarrative.segments,
+      narrative: narrativeAnalysis.text,
+      highlightRanges: narrativeAnalysis.highlightRanges,
+      narrativeWarnings: narrativeAnalysis.warnings,
       closingSentence,
-      hasFormattingAdjustments: normalizedNarrative.hasAdjustments,
     });
   }
 
@@ -652,7 +512,7 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                 id="operation-date-required"
                 className="text-sm font-medium text-destructive"
               >
-                Required
+                {operationDateErrorMessage}
               </p>
             )}
           </div>
@@ -667,14 +527,20 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
               value={narrative}
               aria-invalid={narrativeIsInvalid ? "true" : undefined}
               aria-describedby={
-                narrativeIsInvalid ? "narrative-required" : undefined
+                narrativeIsInvalid
+                  ? "narrative-required"
+                  : hasNarrativeWarnings
+                    ? "narrative-warnings"
+                    : undefined
               }
               onChange={(event) => setNarrative(event.target.value)}
               rows={8}
               className={`flex w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                 narrativeIsInvalid
                   ? "border-destructive focus-visible:ring-destructive"
-                  : "border-input"
+                  : hasNarrativeWarnings
+                    ? "border-amber-500/50 focus-visible:ring-amber-500/30"
+                    : "border-input"
               }`}
             />
 
@@ -685,6 +551,19 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
               >
                 Required
               </p>
+            )}
+
+            {hasNarrativeWarnings && (
+              <div
+                id="narrative-warnings"
+                role="status"
+                aria-label="Narrative Warnings"
+                className="space-y-1 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+              >
+                {recommendation.narrativeWarnings.map((warning) => (
+                  <p key={warning.key}>{warning.message}</p>
+                ))}
+              </div>
             )}
           </div>
 
@@ -717,17 +596,6 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
               <p aria-label="Citation Narrative">
                 {renderCitationNarrative(recommendation)}
               </p>
-
-              {recommendation.hasFormattingAdjustments && (
-                <div
-                  role="status"
-                  aria-label="Formatting Adjustments"
-                  className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
-                >
-                  Formatting adjustments were applied automatically. Review the
-                  highlighted changes before submitting.
-                </div>
-              )}
             </section>
           )}
         </CardContent>

--- a/client/app/medalrecommendation/lib/narrative-validation.js
+++ b/client/app/medalrecommendation/lib/narrative-validation.js
@@ -86,9 +86,7 @@ export function getRankEntries(rosterMembers) {
     }
   }
 
-  return Array.from(rankEntriesByShortName.values()).sort(
-    (a, b) => b.short.length - a.short.length,
-  );
+  return Array.from(rankEntriesByShortName.values());
 }
 
 export function analyzeNarrative(
@@ -132,17 +130,16 @@ export function analyzeNarrative(
       .join("|");
 
     const possibleRankPattern = new RegExp(
-      `(^|[^A-Za-z0-9])(${rankPattern}\\.?)` + `(?=$|[^A-Za-z0-9])`,
+      `(^|[^A-Za-z0-9])((?:${rankPattern})\\.?)` + `(?=$|[^A-Za-z0-9])`,
       "gi",
     );
-
     const warnedRankTokens = new Set();
 
     for (const match of text.matchAll(possibleRankPattern)) {
       const prefix = match[1] ?? "";
       const token = match[2] ?? "";
       const start = (match.index ?? 0) + prefix.length;
-      const warningKey = token.toLowerCase();
+      const warningKey = token.replace(/\.$/, "").toLowerCase();
 
       addHighlightRange(highlightRanges, start, start + token.length);
 

--- a/client/app/medalrecommendation/lib/narrative-validation.js
+++ b/client/app/medalrecommendation/lib/narrative-validation.js
@@ -1,0 +1,279 @@
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildFlexiblePhrasePattern(value) {
+  return value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(escapeRegExp)
+    .join("\\s+");
+}
+
+function addWarning(warnings, key, message) {
+  if (warnings.some((warning) => warning.key === key)) {
+    return;
+  }
+
+  warnings.push({
+    key,
+    message,
+  });
+}
+
+function addHighlightRange(highlightRanges, start, end) {
+  if (start < 0 || end <= start) {
+    return;
+  }
+
+  highlightRanges.push({
+    start,
+    end,
+  });
+}
+
+function findSentenceRanges(text) {
+  const sentenceRanges = [];
+  const sentencePattern = /[^.!?]+[.!?]+/g;
+
+  for (const match of text.matchAll(sentencePattern)) {
+    const rawSentence = match[0];
+
+    const leadingWhitespaceLength = rawSentence.match(/^\s*/)?.[0].length ?? 0;
+
+    const trailingWhitespaceLength = rawSentence.match(/\s*$/)?.[0].length ?? 0;
+
+    const start = (match.index ?? 0) + leadingWhitespaceLength;
+
+    const end =
+      (match.index ?? 0) + rawSentence.length - trailingWhitespaceLength;
+
+    if (end > start) {
+      sentenceRanges.push({
+        start,
+        end,
+        text: text.slice(start, end),
+      });
+    }
+  }
+
+  return sentenceRanges;
+}
+
+export function getRankEntries(rosterMembers) {
+  const rankEntriesByShortName = new Map();
+
+  for (const member of rosterMembers) {
+    const rankShort = member?.rank?.rankShort?.trim() ?? "";
+    const rankFull = member?.rank?.rankFull?.trim() ?? "";
+
+    if (
+      !rankShort ||
+      !rankFull ||
+      rankShort.toLowerCase() === rankFull.toLowerCase()
+    ) {
+      continue;
+    }
+
+    const key = rankShort.toLowerCase();
+
+    if (!rankEntriesByShortName.has(key)) {
+      rankEntriesByShortName.set(key, {
+        short: rankShort,
+        full: rankFull,
+      });
+    }
+  }
+
+  return Array.from(rankEntriesByShortName.values()).sort(
+    (a, b) => b.short.length - a.short.length,
+  );
+}
+
+export function analyzeNarrative(
+  narrative,
+  { recipientRank, recipientCitationName, rankEntries },
+) {
+  const text = narrative.trim();
+  const warnings = [];
+  const highlightRanges = [];
+
+  if (recipientRank && recipientCitationName) {
+    const fullIdentityPattern = new RegExp(
+      `${buildFlexiblePhrasePattern(
+        recipientRank,
+      )}\\s+${buildFlexiblePhrasePattern(recipientCitationName)}`,
+      "i",
+    );
+
+    if (!fullIdentityPattern.test(text)) {
+      addWarning(
+        warnings,
+        "recipient-mention",
+        "Recipient mention: The selected recipient's Full Rank Full Name was not detected in the narrative. Verify that the recipient is identified correctly.",
+      );
+    }
+  }
+
+  const sentenceRanges = findSentenceRanges(text);
+
+  if (sentenceRanges.length < 3) {
+    addWarning(
+      warnings,
+      "sentence-count",
+      "Sentence count: This medal requires a minimum of three sentences. The narrative may not meet that requirement. Please verify before submitting.",
+    );
+  }
+
+  if (rankEntries.length > 0) {
+    const rankPattern = rankEntries
+      .map((rankEntry) => escapeRegExp(rankEntry.short))
+      .join("|");
+
+    const possibleRankPattern = new RegExp(
+      `(^|[^A-Za-z0-9])(${rankPattern}\\.?)` + `(?=$|[^A-Za-z0-9])`,
+      "gi",
+    );
+
+    const warnedRankTokens = new Set();
+
+    for (const match of text.matchAll(possibleRankPattern)) {
+      const prefix = match[1] ?? "";
+      const token = match[2] ?? "";
+      const start = (match.index ?? 0) + prefix.length;
+      const warningKey = token.toLowerCase();
+
+      addHighlightRange(highlightRanges, start, start + token.length);
+
+      if (!warnedRankTokens.has(warningKey)) {
+        warnedRankTokens.add(warningKey);
+
+        addWarning(
+          warnings,
+          `rank-${warningKey}`,
+          `Possible rank usage: "${token}" was detected in the narrative. Verify that this usage and any rank formatting comply with the Medal SOP.`,
+        );
+      }
+    }
+  }
+
+  const duplicateWordPattern = /\b([A-Za-z][A-Za-z'’\-]*)\s+\1\b/giu;
+
+  const warnedDuplicateWords = new Set();
+
+  for (const match of text.matchAll(duplicateWordPattern)) {
+    const duplicateText = match[0];
+    const warningKey = duplicateText.toLowerCase();
+
+    addHighlightRange(
+      highlightRanges,
+      match.index ?? 0,
+      (match.index ?? 0) + duplicateText.length,
+    );
+
+    if (!warnedDuplicateWords.has(warningKey)) {
+      warnedDuplicateWords.add(warningKey);
+
+      addWarning(
+        warnings,
+        `duplicate-word-${warningKey}`,
+        `Possible duplicate: "${duplicateText}" was detected in the narrative. Verify that the repetition is intentional.`,
+      );
+    }
+  }
+
+  const sentenceGroups = new Map();
+
+  for (const sentence of sentenceRanges) {
+    const normalizedSentence = sentence.text
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase();
+
+    if (!normalizedSentence) {
+      continue;
+    }
+
+    const existingRanges = sentenceGroups.get(normalizedSentence) ?? [];
+
+    existingRanges.push(sentence);
+
+    sentenceGroups.set(normalizedSentence, existingRanges);
+  }
+
+  let hasDuplicateSentence = false;
+
+  for (const ranges of sentenceGroups.values()) {
+    if (ranges.length < 2) {
+      continue;
+    }
+
+    hasDuplicateSentence = true;
+
+    for (const range of ranges) {
+      addHighlightRange(highlightRanges, range.start, range.end);
+    }
+  }
+
+  if (hasDuplicateSentence) {
+    addWarning(
+      warnings,
+      "duplicate-sentence",
+      "Possible duplicate sentence: This sentence appears more than once in the narrative. Verify that it was not duplicated accidentally.",
+    );
+  }
+
+  const repeatedPunctuationPattern = /([.,;:!?])\1+/g;
+
+  let hasRepeatedPunctuation = false;
+
+  for (const match of text.matchAll(repeatedPunctuationPattern)) {
+    if (match[0] === "...") {
+      continue;
+    }
+
+    hasRepeatedPunctuation = true;
+
+    addHighlightRange(
+      highlightRanges,
+      match.index ?? 0,
+      (match.index ?? 0) + match[0].length,
+    );
+  }
+
+  if (hasRepeatedPunctuation) {
+    addWarning(
+      warnings,
+      "repeated-punctuation",
+      "Possible punctuation error: Repeated punctuation was detected. Verify this section before submitting.",
+    );
+  }
+
+  return {
+    text,
+    warnings,
+    highlightRanges,
+  };
+}
+
+export function mergeHighlightRanges(highlightRanges) {
+  const sortedRanges = [...highlightRanges].sort(
+    (a, b) => a.start - b.start || a.end - b.end,
+  );
+
+  const mergedRanges = [];
+
+  for (const range of sortedRanges) {
+    const previousRange = mergedRanges[mergedRanges.length - 1];
+
+    if (!previousRange || range.start > previousRange.end) {
+      mergedRanges.push({ ...range });
+      continue;
+    }
+
+    previousRange.end = Math.max(previousRange.end, range.end);
+  }
+
+  return mergedRanges;
+}

--- a/client/app/medalrecommendation/page.jsx
+++ b/client/app/medalrecommendation/page.jsx
@@ -14,7 +14,8 @@ export default async function MedalRecommendationPage() {
 
   try {
     rosterResponse = await GetMedalRecipientRoster();
-  } catch {
+  } catch (error) {
+    console.error("Medal recipient roster fetch failed:", error.message);
     return (
       <main className="mx-auto max-w-4xl px-4 py-6">
         <Card>

--- a/client/app/medalrecommendation/page.jsx
+++ b/client/app/medalrecommendation/page.jsx
@@ -1,17 +1,18 @@
-import GetCombatRoster from "../reusableModules/getCombatRoster";
+import GetMedalRecipientRoster from "../reusableModules/getMedalRecipientRoster";
 import MedalRecommendationClient from "./MedalRecommendationClient";
 
 export const dynamic = "force-dynamic";
+
 export const metadata = {
   title: "Medal Recommendation Aid",
 };
 
 export default async function MedalRecommendationPage() {
-  const rosterResponse = await GetCombatRoster();
+  const rosterResponse = await GetMedalRecipientRoster();
 
   const profiles = Object.values(rosterResponse?.profiles ?? {});
 
-  const combatRoster = profiles.map((profile) => ({
+  const medalRecipientRoster = profiles.map((profile) => ({
     user: {
       userId: profile.user?.userId ?? "",
       username: profile.user?.username ?? "",
@@ -21,7 +22,11 @@ export default async function MedalRecommendationPage() {
       rankFull: profile.rank?.rankFull ?? "",
     },
     realName: profile.realName ?? "",
+    roster: profile.roster ?? "",
+    primary: {
+      positionTitle: profile.primary?.positionTitle ?? "",
+    },
   }));
 
-  return <MedalRecommendationClient combatRoster={combatRoster} />;
+  return <MedalRecommendationClient recipientRoster={medalRecipientRoster} />;
 }

--- a/client/app/medalrecommendation/page.jsx
+++ b/client/app/medalrecommendation/page.jsx
@@ -1,3 +1,5 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import GetMedalRecipientRoster from "../reusableModules/getMedalRecipientRoster";
 import MedalRecommendationClient from "./MedalRecommendationClient";
 
@@ -8,7 +10,38 @@ export const metadata = {
 };
 
 export default async function MedalRecommendationPage() {
-  const rosterResponse = await GetMedalRecipientRoster();
+  let rosterResponse;
+
+  try {
+    rosterResponse = await GetMedalRecipientRoster();
+  } catch {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-6">
+        <Card>
+          <CardHeader>
+            <h2 className="text-2xl font-semibold">
+              Unable to load Medal Recommendation Aid
+            </h2>
+          </CardHeader>
+
+          <CardContent className="space-y-4">
+            <p>
+              The medal recipient roster could not be loaded. Please try again.
+            </p>
+
+            <Button asChild>
+              <a
+                href="/medalrecommendation"
+                className="!text-primary-foreground hover:!text-primary-foreground"
+              >
+                Try Again
+              </a>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
 
   const profiles = Object.values(rosterResponse?.profiles ?? {});
 

--- a/client/app/medalrecommendation/tests/medal-recipient-roster.test.jsx
+++ b/client/app/medalrecommendation/tests/medal-recipient-roster.test.jsx
@@ -1,0 +1,260 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MedalRecommendationPage from "../page";
+
+const medalRecipientRoster = {
+  2000: {
+    user: {
+      userId: "2000",
+      username: "Combat.C",
+    },
+    rank: {
+      rankShort: "SPC",
+      rankFull: "Specialist",
+      rankId: "5",
+    },
+    realName: "Casey Combat",
+    roster: "ROSTER_TYPE_COMBAT",
+    primary: {
+      positionTitle: "Trooper",
+      positionId: "199",
+    },
+    secondaries: [],
+  },
+
+  2001: {
+    user: {
+      userId: "2001",
+      username: "Reserve.R",
+    },
+    rank: {
+      rankShort: "SGT",
+      rankFull: "Sergeant",
+      rankId: "6",
+    },
+    realName: "Riley Reserve",
+    roster: "ROSTER_TYPE_RESERVE",
+    primary: {
+      positionTitle: "Reservist",
+      positionId: "200",
+    },
+    secondaries: [],
+  },
+
+  2002: {
+    user: {
+      userId: "2002",
+      username: "Eloa.E",
+    },
+    rank: {
+      rankShort: "CPL",
+      rankFull: "Corporal",
+      rankId: "4",
+    },
+    realName: "Elliot Eloa",
+    roster: "ROSTER_TYPE_ELOA",
+    primary: {
+      positionTitle: "ELOA",
+      positionId: "201",
+    },
+    secondaries: [],
+  },
+
+  2003: {
+    user: {
+      userId: "2003",
+      username: "Honor.H",
+    },
+    rank: {
+      rankShort: "1SG",
+      rankFull: "First Sergeant",
+      rankId: "8",
+    },
+    realName: "Harper Honor",
+    roster: "ROSTER_TYPE_WALL_OF_HONOR",
+    primary: {
+      positionTitle: "Wall of Honor",
+      positionId: "202",
+    },
+    secondaries: [],
+  },
+
+  2004: {
+    user: {
+      userId: "2004",
+      username: "Retired.R",
+    },
+    rank: {
+      rankShort: "MAJ",
+      rankFull: "Major",
+      rankId: "10",
+    },
+    realName: "Robin Retired",
+    roster: "ROSTER_TYPE_PAST_MEMBERS",
+    primary: {
+      positionTitle: "Retired",
+      positionId: "203",
+    },
+    secondaries: [],
+  },
+};
+
+async function renderMedalRecommendationAid() {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+    if (url === "https://medal-recipient-roster.test/") {
+      return {
+        ok: true,
+        json: async () => ({
+          profiles: medalRecipientRoster,
+        }),
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  });
+
+  render(await MedalRecommendationPage());
+}
+
+async function selectRecipient(user, query, username) {
+  await user.type(
+    screen.getByRole("textbox", {
+      name: "Recipient",
+    }),
+    query,
+  );
+
+  await user.click(
+    await screen.findByRole("button", {
+      name: username,
+    }),
+  );
+}
+
+describe("Medal Recommendation recipient roster", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("lets a user search for and select a Reserve medal recipient", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await selectRecipient(user, "Res", "Reserve.R");
+
+    expect(screen.getByText("Selected recipient: Reserve.R")).toBeVisible();
+
+    expect(screen.getByText("Sergeant Riley Reserve")).toBeVisible();
+  });
+
+  test("does not warn when the selected recipient is an active Combat member", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await selectRecipient(user, "Com", "Combat.C");
+
+    expect(
+      screen.queryByText(
+        /this member is not an active member, please confirm eligibility/i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test.each([
+    ["Reserve", "Res", "Reserve.R"],
+    ["ELOA", "Elo", "Eloa.E"],
+    ["Wall of Honor", "Hon", "Honor.H"],
+    ["Retired", "Ret", "Retired.R"],
+  ])(
+    "warns when the selected recipient is %s",
+    async (_status, query, username) => {
+      const user = userEvent.setup();
+
+      await renderMedalRecommendationAid();
+
+      await selectRecipient(user, query, username);
+
+      expect(
+        screen.getByText(
+          /this member is not an active member, please confirm eligibility/i,
+        ),
+      ).toBeVisible();
+    },
+  );
+
+  test("allows generation for a non-active recipient after showing the eligibility warning", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await selectRecipient(user, "Res", "Reserve.R");
+
+    expect(
+      screen.getByText(
+        /this member is not an active member, please confirm eligibility/i,
+      ),
+    ).toBeVisible();
+
+    await user.click(
+      screen.getByRole("combobox", {
+        name: "Action Character",
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("option", {
+        name: "Skillful",
+      }),
+    );
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: "Combat Element",
+      }),
+      "rifleman",
+    );
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: "Operation Title",
+      }),
+      "Exfor",
+    );
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: "Location",
+      }),
+      "Remagen",
+    );
+
+    await user.type(screen.getByLabelText("Operation Date"), "2026-08-11");
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: "Narrative",
+      }),
+      "SGT Reserve maintained the position throughout the operation.",
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText(
+        /this member is not an active member, please confirm eligibility/i,
+      ),
+    ).toBeVisible();
+  });
+});

--- a/client/app/medalrecommendation/tests/medal-recommendation.test.jsx
+++ b/client/app/medalrecommendation/tests/medal-recommendation.test.jsx
@@ -290,6 +290,30 @@ describe("Medal Recommendation Aid", () => {
     expect(screen.getByText("Army Commendation Medal")).toBeVisible();
   });
 
+  test("shows a graceful unavailable state when the medal recipient roster cannot be loaded", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
+      new TypeError("fetch failed"),
+    );
+
+    render(await MedalRecommendationPage());
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Unable to load Medal Recommendation Aid",
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText(/the medal recipient roster could not be loaded/i),
+    ).toBeVisible();
+
+    const retryLink = screen.getByRole("link", {
+      name: "Try Again",
+    });
+
+    expect(retryLink).toHaveAttribute("href", "/medalrecommendation");
+  });
+
   test("does not show required-field errors before generation is attempted", async () => {
     await renderMedalRecommendationAid();
 
@@ -746,6 +770,138 @@ describe("Medal Recommendation Aid", () => {
     ).not.toBeInTheDocument();
   });
 
+  test("clears the generated preview when the narrative changes", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "SPC Smith maintained an effective fighting position throughout the operation. " +
+      "He repeatedly engaged enemy forces and supported his squad during each major contact. " +
+      "His performance contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).toBeVisible();
+
+    const narrativeField = screen.getByRole("textbox", {
+      name: "Narrative",
+    });
+
+    await user.type(narrativeField, " Additional text.");
+
+    expect(
+      screen.queryByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test.each([
+    [
+      "Action Character",
+      async (user) => {
+        await user.click(
+          screen.getByRole("combobox", {
+            name: "Action Character",
+          }),
+        );
+
+        await user.click(
+          screen.getByRole("option", {
+            name: "Heroic",
+          }),
+        );
+      },
+    ],
+    [
+      "Combat Element",
+      async (user) => {
+        const field = screen.getByRole("textbox", {
+          name: "Combat Element",
+        });
+
+        await user.clear(field);
+        await user.type(field, "squad leader");
+      },
+    ],
+    [
+      "Operation Title",
+      async (user) => {
+        const field = screen.getByRole("textbox", {
+          name: "Operation Title",
+        });
+
+        await user.clear(field);
+        await user.type(field, "Operation Market Garden");
+      },
+    ],
+    [
+      "Location",
+      async (user) => {
+        const field = screen.getByRole("textbox", {
+          name: "Location",
+        });
+
+        await user.clear(field);
+        await user.type(field, "Arnhem");
+      },
+    ],
+    [
+      "Operation Date",
+      async (user) => {
+        const field = screen.getByLabelText("Operation Date");
+
+        await user.clear(field);
+        await user.type(field, "2026-08-10");
+      },
+    ],
+  ])(
+    "clears the generated preview when %s changes",
+    async (_field, changeField) => {
+      const user = userEvent.setup();
+
+      await renderMedalRecommendationAid();
+
+      const narrative =
+        "SPC Smith maintained an effective fighting position throughout the operation. " +
+        "He repeatedly engaged enemy forces and supported his squad during each major contact. " +
+        "His performance contributed directly to the successful completion of the operation.";
+
+      await completeRecommendation(user, narrative);
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Generate Recommendation",
+        }),
+      );
+
+      expect(
+        screen.getByRole("region", {
+          name: "Recommendation Preview",
+        }),
+      ).toBeVisible();
+
+      await changeField(user);
+
+      expect(
+        screen.queryByRole("region", {
+          name: "Recommendation Preview",
+        }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
   test("generates a complete Army Commendation Medal recommendation", async () => {
     const user = userEvent.setup();
 
@@ -836,6 +992,101 @@ describe("Medal Recommendation Aid", () => {
         name: "Recipient Full Name",
       }),
     ).not.toBeInTheDocument();
+  });
+
+  test.each(["SPC.", "CPL.", "MG."])(
+    "highlights the full abbreviated rank including the period for %s",
+    async (rankToken) => {
+      const user = userEvent.setup();
+
+      await renderMedalRecommendationAid();
+
+      const narrative =
+        "Specialist John Smith maintained the defensive position during the opening engagement. " +
+        `The ${rankToken} Kenton moved forward to reinforce the squad. ` +
+        "The unit maintained control of the objective through the final contact.";
+
+      await completeRecommendation(user, narrative);
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Generate Recommendation",
+        }),
+      );
+
+      const citation = screen.getByLabelText("Citation Narrative");
+
+      const highlights = Array.from(citation.querySelectorAll("mark")).map(
+        (highlight) => highlight.textContent,
+      );
+
+      expect(highlights).toContain(rankToken);
+    },
+  );
+
+  test("preserves citation text exactly when highlight ranges overlap", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "The MG jammed. " +
+      "The MG jammed. " +
+      "Specialist John Smith cleared it.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    const expectedCitation =
+      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
+      narrative +
+      " Specialist John Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
+
+    expect(citation.textContent).toBe(expectedCitation);
+  });
+
+  test("shows one rank warning when the same abbreviation appears with and without a period", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist John Smith maintained the defensive position during the opening engagement. " +
+      "MG Kenton coordinated the supporting element during the assault. " +
+      "MG. Kenton continued directing the element through the final contact.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const warnings = screen.getByRole("status", {
+      name: "Narrative Warnings",
+    });
+
+    const rankWarnings = Array.from(warnings.querySelectorAll("p")).filter(
+      (warning) => warning.textContent.startsWith("Possible rank usage:"),
+    );
+
+    expect(rankWarnings).toHaveLength(1);
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    const rankHighlights = Array.from(citation.querySelectorAll("mark"))
+      .map((highlight) => highlight.textContent)
+      .filter((text) => text === "MG" || text === "MG.");
+
+    expect(rankHighlights).toEqual(["MG", "MG."]);
   });
 
   test("warns about a possible rank abbreviation without rewriting the narrative", async () => {

--- a/client/app/medalrecommendation/tests/medal-recommendation.test.jsx
+++ b/client/app/medalrecommendation/tests/medal-recommendation.test.jsx
@@ -147,6 +147,24 @@ const combatRoster = {
     },
     secondaries: [],
   },
+  1009: {
+    user: {
+      userId: "1009",
+      username: "Kenton.W",
+    },
+    rank: {
+      rankShort: "Cpl",
+      rankFull: "Corporal",
+      rankId: "6",
+    },
+    realName: "Wade Kenton",
+    roster: "ROSTER_TYPE_COMBAT",
+    primary: {
+      positionTitle: "Trooper",
+      positionId: "108",
+    },
+    secondaries: [],
+  },
 };
 
 async function renderMedalRecommendationAid() {
@@ -254,6 +272,31 @@ describe("Medal Recommendation Aid", () => {
     expect(screen.getByText("Army Commendation Medal")).toBeVisible();
   });
 
+  test("does not show required-field errors before generation is attempted", async () => {
+    await renderMedalRecommendationAid();
+
+    expect(
+      screen.getByRole("textbox", {
+        name: "Recipient",
+      }),
+    ).not.toHaveAttribute("aria-invalid", "true");
+
+    expect(
+      screen.getByRole("combobox", {
+        name: "Action Character",
+      }),
+    ).not.toHaveAttribute("aria-invalid", "true");
+
+    expect(
+      screen.getByRole("textbox", {
+        name: "Combat Element",
+      }),
+    ).not.toHaveAttribute("aria-invalid", "true");
+
+    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   test("lets a user search for and select a medal recipient", async () => {
     const user = userEvent.setup();
 
@@ -264,6 +307,31 @@ describe("Medal Recommendation Aid", () => {
     expect(screen.getByText("Selected recipient: Smith.J")).toBeVisible();
 
     expect(screen.getByText("Specialist John Smith")).toBeVisible();
+  });
+
+  test("filters recipient suggestions to usernames matching the search", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: "Recipient",
+      }),
+      "Smi",
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Smith.J",
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Long.A",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   test("prevents generation when Action Character is missing", async () => {
@@ -442,6 +510,169 @@ describe("Medal Recommendation Aid", () => {
     ).not.toBeInTheDocument();
   });
 
+  test("marks a missing required field as invalid after generation is attempted", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "SPC Smith maintained an effective fighting position throughout the operation.",
+      {
+        omit: "combatElement",
+      },
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const combatElement = screen.getByRole("textbox", {
+      name: "Combat Element",
+    });
+
+    expect(combatElement).toHaveAttribute("aria-invalid", "true");
+    expect(combatElement).toHaveAccessibleDescription("Required");
+    expect(combatElement).toHaveClass("border-destructive");
+
+    expect(screen.getByText("Required")).toBeVisible();
+
+    expect(
+      screen.getByRole("textbox", {
+        name: "Operation Title",
+      }),
+    ).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  test("clears a required field error immediately when the user fixes the field", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "SPC Smith maintained an effective fighting position throughout the operation.",
+      {
+        omit: "combatElement",
+      },
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const combatElement = screen.getByRole("textbox", {
+      name: "Combat Element",
+    });
+
+    expect(combatElement).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Required")).toBeVisible();
+
+    await user.type(combatElement, "rifleman");
+
+    expect(combatElement).not.toHaveAttribute("aria-invalid", "true");
+
+    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+  });
+
+  test("clears attempted validation state after a successful generation", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "SPC Smith maintained an effective fighting position throughout the operation.",
+      {
+        omit: "combatElement",
+      },
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const combatElement = screen.getByRole("textbox", {
+      name: "Combat Element",
+    });
+
+    expect(combatElement).toHaveAttribute("aria-invalid", "true");
+
+    await user.type(combatElement, "rifleman");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).toBeVisible();
+
+    await user.clear(combatElement);
+
+    expect(combatElement).not.toHaveAttribute("aria-invalid", "true");
+    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  test("marks every missing required control when an empty recommendation is submitted", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const requiredControls = [
+      screen.getByRole("textbox", {
+        name: "Recipient",
+      }),
+      screen.getByRole("combobox", {
+        name: "Action Character",
+      }),
+      screen.getByRole("textbox", {
+        name: "Combat Element",
+      }),
+      screen.getByRole("textbox", {
+        name: "Operation Title",
+      }),
+      screen.getByRole("textbox", {
+        name: "Location",
+      }),
+      screen.getByLabelText("Operation Date"),
+      screen.getByRole("textbox", {
+        name: "Narrative",
+      }),
+    ];
+
+    for (const control of requiredControls) {
+      expect(control).toHaveAttribute("aria-invalid", "true");
+      expect(control).toHaveAccessibleDescription("Required");
+      expect(control).toHaveClass("border-destructive");
+    }
+
+    expect(screen.getAllByText("Required")).toHaveLength(7);
+
+    expect(
+      screen.queryByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   test("clears the previous recommendation when regeneration fails", async () => {
     const user = userEvent.setup();
 
@@ -555,7 +786,7 @@ describe("Medal Recommendation Aid", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("normalizes only the first recipient mention and leaves later narrative mentions unchanged", async () => {
+  test("normalizes selected-recipient references throughout the narrative body", async () => {
     const user = userEvent.setup();
 
     await renderMedalRecommendationAid();
@@ -578,13 +809,285 @@ describe("Medal Recommendation Aid", () => {
     expect(citation).toHaveTextContent(
       "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
         "Specialist John Smith maintained an effective fighting position throughout the operation. " +
-        "Smith continued to support the squad during each major contact. " +
-        "John Smith completed the operation while maintaining control of the position. " +
+        "Specialist Smith continued to support the squad during each major contact. " +
+        "Specialist Smith completed the operation while maintaining control of the position. " +
         "Specialist John Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.",
     );
   });
 
-  test("leaves later common-word surname text unchanged", async () => {
+  test("expands an abbreviated rank for another Trooper in the narrative", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "SPC Smith maintained the defensive position during the opening engagement. " +
+      "SPC Perrier moved forward to reinforce the squad.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(citation).toHaveTextContent(
+      "Specialist John Smith maintained the defensive position during the opening engagement. " +
+        "Specialist Perrier moved forward to reinforce the squad.",
+    );
+
+    expect(citation).not.toHaveTextContent("SPC Perrier");
+  });
+
+  test("shows a soft formatting notice when the generator changes narrative text", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "SPC Smith maintained the defensive position during the opening engagement.",
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("status", {
+        name: "Formatting Adjustments",
+      }),
+    ).toHaveTextContent(
+      "Formatting adjustments were applied automatically. Review the highlighted changes before submitting.",
+    );
+  });
+
+  test("softly highlights only references automatically changed inside the narrative", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Cpl Kenton helped SPC Perrier during the engagement. " +
+      "Cpl Kenton won the engagement.";
+
+    await completeRecommendation(user, narrative, {
+      recipientQuery: "Ken",
+      recipientUsername: "Kenton.W",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+    const highlights = Array.from(citation.querySelectorAll("mark"));
+
+    expect(highlights).toHaveLength(3);
+    expect(highlights[0]).toHaveTextContent(/^Corporal Wade Kenton$/);
+    expect(highlights[1]).toHaveTextContent(/^Specialist Perrier$/);
+    expect(highlights[2]).toHaveTextContent(/^Corporal Kenton$/);
+
+    for (const highlight of highlights) {
+      expect(highlight).toHaveClass("bg-amber-400/10");
+      expect(highlight).toHaveClass("text-inherit");
+      expect(highlight).not.toHaveClass("bg-amber-300");
+      expect(highlight).not.toHaveClass("text-black");
+    }
+  });
+
+  test("does not mark generated opening or closing language as a formatting adjustment", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "Cpl Kenton helped SPC Perrier during the engagement.",
+      {
+        recipientQuery: "Ken",
+        recipientUsername: "Kenton.W",
+      },
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+    const highlights = Array.from(citation.querySelectorAll("mark"));
+
+    expect(highlights).toHaveLength(2);
+
+    expect(
+      highlights.some((highlight) =>
+        highlight.textContent.includes(
+          "For skillful actions over an entire operation",
+        ),
+      ),
+    ).toBe(false);
+
+    expect(
+      highlights.some((highlight) =>
+        highlight.textContent.includes("reflect great credit upon themselves"),
+      ),
+    ).toBe(false);
+  });
+
+  test("normalizes abbreviated ranks without requiring matching capitalization", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "spc smith maintained the defensive position during the opening engagement. " +
+      "cpl Kenton moved forward to reinforce the squad.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(citation).toHaveTextContent(
+      "Specialist John Smith maintained the defensive position during the opening engagement. " +
+        "Corporal Kenton moved forward to reinforce the squad.",
+    );
+
+    expect(citation).not.toHaveTextContent("spc smith");
+    expect(citation).not.toHaveTextContent("cpl Kenton");
+  });
+
+  test("does not show formatting adjustments when the narrative already follows the rank and name format", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist John Smith maintained the defensive position during the opening engagement. " +
+      "Specialist Smith continued to support the squad throughout the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.queryByRole("status", {
+        name: "Formatting Adjustments",
+      }),
+    ).not.toBeInTheDocument();
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(citation.querySelector("mark")).not.toBeInTheDocument();
+  });
+
+  test("recomputes formatting adjustments when the user corrects the narrative and regenerates", async () => {
+    const user = userEvent.setup();
+
+    const originalNarrative =
+      "Cpl Kenton helped SPC Perrier during the engagement. " +
+      "Cpl Kenton won the engagement.";
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(user, originalNarrative, {
+      recipientQuery: "Ken",
+      recipientUsername: "Kenton.W",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("status", {
+        name: "Formatting Adjustments",
+      }),
+    ).toBeVisible();
+
+    const narrative = screen.getByRole("textbox", {
+      name: "Narrative",
+    });
+
+    await user.clear(narrative);
+    await user.type(
+      narrative,
+      "Corporal Wade Kenton helped Specialist Perrier during the engagement. " +
+        "Corporal Kenton won the engagement.",
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.queryByRole("status", {
+        name: "Formatting Adjustments",
+      }),
+    ).not.toBeInTheDocument();
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(citation.querySelector("mark")).not.toBeInTheDocument();
+  });
+
+  test("keeps the worksheet narrative unchanged while normalizing the generated citation", async () => {
+    const user = userEvent.setup();
+
+    const originalNarrative =
+      "Cpl Kenton helped SPC Perrier during the engagement. " +
+      "Cpl Kenton won the engagement.";
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(user, originalNarrative, {
+      recipientQuery: "Ken",
+      recipientUsername: "Kenton.W",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("textbox", {
+        name: "Narrative",
+      }),
+    ).toHaveValue(originalNarrative);
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(citation).toHaveTextContent(
+      "Corporal Wade Kenton helped Specialist Perrier during the engagement. " +
+        "Corporal Kenton won the engagement.",
+    );
+  });
+
+  test("normalizes selected-recipient references without changing ordinary common-word surname text", async () => {
     const user = userEvent.setup();
 
     await renderMedalRecommendationAid();
@@ -610,13 +1113,13 @@ describe("Medal Recommendation Aid", () => {
     expect(citation).toHaveTextContent(
       "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
         "Specialist Adam Long secured the position during the opening engagement. " +
-        "It was a long night, but SPC Long continued to hold the line. " +
-        "Adam Long completed the operation after the final enemy attack. " +
+        "It was a long night, but Specialist Long continued to hold the line. " +
+        "Specialist Long completed the operation after the final enemy attack. " +
         "Specialist Adam Long's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.",
     );
   });
 
-  test("removes middle names from generated recipient text and leaves later mentions unchanged", async () => {
+  test("removes middle names and normalizes later selected-recipient references", async () => {
     const user = userEvent.setup();
 
     await renderMedalRecommendationAid();
@@ -649,8 +1152,8 @@ describe("Medal Recommendation Aid", () => {
     expect(citation).toHaveTextContent(
       "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
         "Specialist Taylor Smith established the defensive position before the main engagement. " +
-        "Smith continued to support the squad during each major contact. " +
-        "Taylor Smith maintained control of the position through the final attack. " +
+        "Specialist Smith continued to support the squad during each major contact. " +
+        "Specialist Smith maintained control of the position through the final attack. " +
         "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.",
     );
   });
@@ -987,7 +1490,7 @@ describe("Medal Recommendation Aid", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("normalizes an explicit full-rank full-roster-name first mention", async () => {
+  test("normalizes an explicit full-rank full-roster-name first mention and later references", async () => {
     const user = userEvent.setup();
 
     await renderMedalRecommendationAid();
@@ -1012,7 +1515,7 @@ describe("Medal Recommendation Aid", () => {
     const expectedCitation =
       "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
       "Specialist Taylor Smith established the defensive position. " +
-      "Taylor Smith maintained control through the final engagement. " +
+      "Specialist Smith maintained control through the final engagement. " +
       "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
 
     expect(citation.textContent).toBe(expectedCitation);
@@ -1040,7 +1543,7 @@ describe("Medal Recommendation Aid", () => {
     const expectedCitation =
       "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
       "Specialist John Smith maintained the defensive position. " +
-      "Smith continued to support the squad. " +
+      "Specialist Smith continued to support the squad. " +
       "Specialist John Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
 
     expect(citation.textContent).toBe(expectedCitation);
@@ -1073,6 +1576,13 @@ describe("Medal Recommendation Aid", () => {
       "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
 
     expect(citation.textContent).toBe(expectedCitation);
+    expect(citation.querySelector("mark")).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("status", {
+        name: "Formatting Adjustments",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   test("normalizes a first mention containing regex characters in the roster name", async () => {
@@ -1100,7 +1610,7 @@ describe("Medal Recommendation Aid", () => {
     const expectedCitation =
       "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
       "Specialist Taylor Smith maintained the defensive position throughout the operation. " +
-      "Taylor Smith continued to support the squad. " +
+      "Specialist Smith continued to support the squad. " +
       "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
 
     expect(citation.textContent).toBe(expectedCitation);

--- a/client/app/medalrecommendation/tests/medal-recommendation.test.jsx
+++ b/client/app/medalrecommendation/tests/medal-recommendation.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MedalRecommendationPage from "../page";
 
@@ -162,6 +162,24 @@ const combatRoster = {
     primary: {
       positionTitle: "Trooper",
       positionId: "108",
+    },
+    secondaries: [],
+  },
+  1010: {
+    user: {
+      userId: "1010",
+      username: "General.M",
+    },
+    rank: {
+      rankShort: "MG",
+      rankFull: "Major General",
+      rankId: "12",
+    },
+    realName: "Morgan General",
+    roster: "ROSTER_TYPE_COMBAT",
+    primary: {
+      positionTitle: "Trooper",
+      positionId: "109",
     },
     secondaries: [],
   },
@@ -679,7 +697,7 @@ describe("Medal Recommendation Aid", () => {
     await renderMedalRecommendationAid();
 
     const narrative =
-      "SPC Smith maintained an effective fighting position throughout the operation. " +
+      "Specialist John Smith maintained an effective fighting position throughout the operation. " +
       "He repeatedly engaged enemy forces and supported his squad during each major contact. " +
       "His performance contributed directly to the successful completion of the operation.";
 
@@ -734,7 +752,7 @@ describe("Medal Recommendation Aid", () => {
     await renderMedalRecommendationAid();
 
     const narrative =
-      "SPC Smith maintained an effective fighting position throughout the operation. " +
+      "Specialist John Smith maintained an effective fighting position throughout the operation. " +
       "He repeatedly engaged enemy forces and supported his squad during each major contact. " +
       "His performance contributed directly to the successful completion of the operation.";
 
@@ -764,6 +782,40 @@ describe("Medal Recommendation Aid", () => {
     );
   });
 
+  test("does not duplicate Operation when the Operation Title already includes it", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "SPC Smith maintained an effective fighting position throughout the operation. " +
+      "He repeatedly engaged enemy forces and supported his squad during each major contact. " +
+      "His performance contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    const operationTitle = screen.getByRole("textbox", {
+      name: "Operation Title",
+    });
+
+    await user.clear(operationTitle);
+    await user.type(operationTitle, "Operation Exfor");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(citation).toHaveTextContent(
+      "during combat in Operation Exfor near Remagen",
+    );
+
+    expect(citation).not.toHaveTextContent("Operation Operation Exfor");
+  });
+
   test("uses the selected roster member identity without asking the user to re-enter it", async () => {
     const user = userEvent.setup();
 
@@ -786,353 +838,17 @@ describe("Medal Recommendation Aid", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("normalizes selected-recipient references throughout the narrative body", async () => {
+  test("warns about a possible rank abbreviation without rewriting the narrative", async () => {
     const user = userEvent.setup();
 
     await renderMedalRecommendationAid();
 
     const narrative =
-      "SPC Smith maintained an effective fighting position throughout the operation. " +
-      "Smith continued to support the squad during each major contact. " +
-      "John Smith completed the operation while maintaining control of the position.";
+      "Specialist John Smith dodged MG Fire while advancing toward the objective. " +
+      "He maintained the defensive position throughout the engagement. " +
+      "His actions contributed directly to the successful completion of the operation.";
 
     await completeRecommendation(user, narrative);
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    expect(citation).toHaveTextContent(
-      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
-        "Specialist John Smith maintained an effective fighting position throughout the operation. " +
-        "Specialist Smith continued to support the squad during each major contact. " +
-        "Specialist Smith completed the operation while maintaining control of the position. " +
-        "Specialist John Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.",
-    );
-  });
-
-  test("expands an abbreviated rank for another Trooper in the narrative", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "SPC Smith maintained the defensive position during the opening engagement. " +
-      "SPC Perrier moved forward to reinforce the squad.";
-
-    await completeRecommendation(user, narrative);
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    expect(citation).toHaveTextContent(
-      "Specialist John Smith maintained the defensive position during the opening engagement. " +
-        "Specialist Perrier moved forward to reinforce the squad.",
-    );
-
-    expect(citation).not.toHaveTextContent("SPC Perrier");
-  });
-
-  test("shows a soft formatting notice when the generator changes narrative text", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    await completeRecommendation(
-      user,
-      "SPC Smith maintained the defensive position during the opening engagement.",
-    );
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    expect(
-      screen.getByRole("status", {
-        name: "Formatting Adjustments",
-      }),
-    ).toHaveTextContent(
-      "Formatting adjustments were applied automatically. Review the highlighted changes before submitting.",
-    );
-  });
-
-  test("softly highlights only references automatically changed inside the narrative", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "Cpl Kenton helped SPC Perrier during the engagement. " +
-      "Cpl Kenton won the engagement.";
-
-    await completeRecommendation(user, narrative, {
-      recipientQuery: "Ken",
-      recipientUsername: "Kenton.W",
-    });
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    const citation = screen.getByLabelText("Citation Narrative");
-    const highlights = Array.from(citation.querySelectorAll("mark"));
-
-    expect(highlights).toHaveLength(3);
-    expect(highlights[0]).toHaveTextContent(/^Corporal Wade Kenton$/);
-    expect(highlights[1]).toHaveTextContent(/^Specialist Perrier$/);
-    expect(highlights[2]).toHaveTextContent(/^Corporal Kenton$/);
-
-    for (const highlight of highlights) {
-      expect(highlight).toHaveClass("bg-amber-400/10");
-      expect(highlight).toHaveClass("text-inherit");
-      expect(highlight).not.toHaveClass("bg-amber-300");
-      expect(highlight).not.toHaveClass("text-black");
-    }
-  });
-
-  test("does not mark generated opening or closing language as a formatting adjustment", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    await completeRecommendation(
-      user,
-      "Cpl Kenton helped SPC Perrier during the engagement.",
-      {
-        recipientQuery: "Ken",
-        recipientUsername: "Kenton.W",
-      },
-    );
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    const citation = screen.getByLabelText("Citation Narrative");
-    const highlights = Array.from(citation.querySelectorAll("mark"));
-
-    expect(highlights).toHaveLength(2);
-
-    expect(
-      highlights.some((highlight) =>
-        highlight.textContent.includes(
-          "For skillful actions over an entire operation",
-        ),
-      ),
-    ).toBe(false);
-
-    expect(
-      highlights.some((highlight) =>
-        highlight.textContent.includes("reflect great credit upon themselves"),
-      ),
-    ).toBe(false);
-  });
-
-  test("normalizes abbreviated ranks without requiring matching capitalization", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "spc smith maintained the defensive position during the opening engagement. " +
-      "cpl Kenton moved forward to reinforce the squad.";
-
-    await completeRecommendation(user, narrative);
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    expect(citation).toHaveTextContent(
-      "Specialist John Smith maintained the defensive position during the opening engagement. " +
-        "Corporal Kenton moved forward to reinforce the squad.",
-    );
-
-    expect(citation).not.toHaveTextContent("spc smith");
-    expect(citation).not.toHaveTextContent("cpl Kenton");
-  });
-
-  test("does not show formatting adjustments when the narrative already follows the rank and name format", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "Specialist John Smith maintained the defensive position during the opening engagement. " +
-      "Specialist Smith continued to support the squad throughout the operation.";
-
-    await completeRecommendation(user, narrative);
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    expect(
-      screen.queryByRole("status", {
-        name: "Formatting Adjustments",
-      }),
-    ).not.toBeInTheDocument();
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    expect(citation.querySelector("mark")).not.toBeInTheDocument();
-  });
-
-  test("recomputes formatting adjustments when the user corrects the narrative and regenerates", async () => {
-    const user = userEvent.setup();
-
-    const originalNarrative =
-      "Cpl Kenton helped SPC Perrier during the engagement. " +
-      "Cpl Kenton won the engagement.";
-
-    await renderMedalRecommendationAid();
-
-    await completeRecommendation(user, originalNarrative, {
-      recipientQuery: "Ken",
-      recipientUsername: "Kenton.W",
-    });
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    expect(
-      screen.getByRole("status", {
-        name: "Formatting Adjustments",
-      }),
-    ).toBeVisible();
-
-    const narrative = screen.getByRole("textbox", {
-      name: "Narrative",
-    });
-
-    await user.clear(narrative);
-    await user.type(
-      narrative,
-      "Corporal Wade Kenton helped Specialist Perrier during the engagement. " +
-        "Corporal Kenton won the engagement.",
-    );
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    expect(
-      screen.queryByRole("status", {
-        name: "Formatting Adjustments",
-      }),
-    ).not.toBeInTheDocument();
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    expect(citation.querySelector("mark")).not.toBeInTheDocument();
-  });
-
-  test("keeps the worksheet narrative unchanged while normalizing the generated citation", async () => {
-    const user = userEvent.setup();
-
-    const originalNarrative =
-      "Cpl Kenton helped SPC Perrier during the engagement. " +
-      "Cpl Kenton won the engagement.";
-
-    await renderMedalRecommendationAid();
-
-    await completeRecommendation(user, originalNarrative, {
-      recipientQuery: "Ken",
-      recipientUsername: "Kenton.W",
-    });
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    expect(
-      screen.getByRole("textbox", {
-        name: "Narrative",
-      }),
-    ).toHaveValue(originalNarrative);
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    expect(citation).toHaveTextContent(
-      "Corporal Wade Kenton helped Specialist Perrier during the engagement. " +
-        "Corporal Kenton won the engagement.",
-    );
-  });
-
-  test("normalizes selected-recipient references without changing ordinary common-word surname text", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "SPC Long secured the position during the opening engagement. " +
-      "It was a long night, but SPC Long continued to hold the line. " +
-      "Adam Long completed the operation after the final enemy attack.";
-
-    await completeRecommendation(user, narrative, {
-      recipientQuery: "Lon",
-      recipientUsername: "Long.A",
-    });
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    expect(citation).toHaveTextContent(
-      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
-        "Specialist Adam Long secured the position during the opening engagement. " +
-        "It was a long night, but Specialist Long continued to hold the line. " +
-        "Specialist Long completed the operation after the final enemy attack. " +
-        "Specialist Adam Long's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.",
-    );
-  });
-
-  test("removes middle names and normalizes later selected-recipient references", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "SPC Smith established the defensive position before the main engagement. " +
-      "Smith continued to support the squad during each major contact. " +
-      "Taylor Smith maintained control of the position through the final attack.";
-
-    await completeRecommendation(user, narrative, {
-      recipientQuery: "Smi",
-      recipientUsername: "Smith.TM",
-    });
 
     await user.click(
       screen.getByRole("button", {
@@ -1143,19 +859,375 @@ describe("Medal Recommendation Aid", () => {
     const preview = screen.getByRole("region", {
       name: "Recommendation Preview",
     });
+    const citation = screen.getByLabelText("Citation Narrative");
 
-    expect(preview).toHaveTextContent("Specialist Taylor Smith");
-    expect(preview).not.toHaveTextContent("Taylor Morgan Smith");
+    expect(preview).toBeVisible();
+    expect(citation).toHaveTextContent(narrative);
+
+    expect(
+      screen.getByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).toHaveTextContent(
+      'Possible rank usage: "MG" was detected in the narrative. Verify that this usage and any rank formatting comply with the Medal SOP.',
+    );
+
+    const highlights = Array.from(citation.querySelectorAll("mark"));
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toHaveTextContent(/^MG$/);
+    expect(citation).toHaveTextContent("dodged MG Fire");
+    expect(citation).not.toHaveTextContent("dodged Major General Fire");
+  });
+
+  test("warns when the selected recipient Full Rank Full Name is not detected without highlighting the whole citation", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist Smith maintained the defensive position throughout the operation. " +
+      "He repeatedly engaged enemy forces during each major contact. " +
+      "His actions contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const preview = screen.getByRole("region", {
+      name: "Recommendation Preview",
+    });
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(preview).toBeVisible();
+
+    expect(
+      screen.getByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).toHaveTextContent(
+      "Recipient mention: The selected recipient's Full Rank Full Name was not detected in the narrative. Verify that the recipient is identified correctly.",
+    );
+
+    expect(citation.querySelector("mark")).not.toBeInTheDocument();
+  });
+
+  test("does not show a recipient-mention warning when Full Rank Full Name is present", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist John Smith maintained the defensive position throughout the operation. " +
+      "He repeatedly engaged enemy forces during each major contact. " +
+      "His actions contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.queryByText(
+        /the selected recipient's full rank full name was not detected in the narrative/i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test("accepts the citation name format when a roster name contains a middle name or initial", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist Taylor Smith maintained the defensive position throughout the operation. " +
+      "He repeatedly engaged enemy forces during each major contact. " +
+      "His actions contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative, {
+      recipientQuery: "Smith.TJ",
+      recipientUsername: "Smith.TJ",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).toHaveTextContent("Specialist Taylor Smith");
+
+    expect(
+      screen.queryByText(
+        /the selected recipient's full rank full name was not detected in the narrative/i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows a soft sentence-count warning without blocking generation", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "Specialist John Smith maintained the defensive position throughout the operation.",
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("region", {
+        name: "Recommendation Preview",
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).toHaveTextContent(
+      "Sentence count: This medal requires a minimum of three sentences. The narrative may not meet that requirement. Please verify before submitting.",
+    );
+  });
+
+  test("warns about a consecutive duplicate word and highlights only the duplicated words", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist John Smith maintained the the defensive position throughout the operation. " +
+      "He repeatedly engaged enemy forces during each major contact. " +
+      "His actions contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
 
     const citation = screen.getByLabelText("Citation Narrative");
 
-    expect(citation).toHaveTextContent(
-      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
-        "Specialist Taylor Smith established the defensive position before the main engagement. " +
-        "Specialist Smith continued to support the squad during each major contact. " +
-        "Specialist Smith maintained control of the position through the final attack. " +
-        "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.",
+    expect(
+      screen.getByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).toHaveTextContent(
+      'Possible duplicate: "the the" was detected in the narrative. Verify that the repetition is intentional.',
     );
+
+    const highlights = Array.from(citation.querySelectorAll("mark"));
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toHaveTextContent(/^the the$/);
+    expect(citation).toHaveTextContent(narrative);
+  });
+
+  test("warns about an exact duplicate sentence and highlights both copies", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const duplicatedSentence =
+      "Specialist John Smith secured the defensive position.";
+
+    const narrative =
+      `${duplicatedSentence} ${duplicatedSentence} ` +
+      "His actions contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(
+      screen.getByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).toHaveTextContent(
+      "Possible duplicate sentence: This sentence appears more than once in the narrative. Verify that it was not duplicated accidentally.",
+    );
+
+    const duplicateHighlights = Array.from(
+      citation.querySelectorAll("mark"),
+    ).filter((highlight) => highlight.textContent === duplicatedSentence);
+
+    expect(duplicateHighlights).toHaveLength(2);
+    expect(citation).toHaveTextContent(narrative);
+  });
+
+  test("warns about repeated punctuation and highlights only the punctuation", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist John Smith maintained the defensive position,, while the squad advanced. " +
+      "He repeatedly engaged enemy forces during each major contact. " +
+      "His actions contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(
+      screen.getByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).toHaveTextContent(
+      "Possible punctuation error: Repeated punctuation was detected. Verify this section before submitting.",
+    );
+
+    const highlights = Array.from(citation.querySelectorAll("mark"));
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toHaveTextContent(/^,,$/);
+    expect(citation).toHaveTextContent(narrative);
+  });
+
+  test("does not warn about a standard three-dot ellipsis", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    const narrative =
+      "Specialist John Smith maintained the defensive position... despite sustained enemy fire. " +
+      "He repeatedly supported his squad during each major contact. " +
+      "His actions contributed directly to the successful completion of the operation.";
+
+    await completeRecommendation(user, narrative);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    const citation = screen.getByLabelText("Citation Narrative");
+
+    expect(
+      screen.queryByText(/possible punctuation error/i),
+    ).not.toBeInTheDocument();
+
+    expect(citation).toHaveTextContent("position... despite");
+    expect(citation).toHaveTextContent(narrative);
+  });
+
+  test("clears narrative warnings when the user corrects the narrative and regenerates", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "Specialist John Smith maintained the the defensive position throughout the operation. " +
+        "He repeatedly engaged enemy forces during each major contact. " +
+        "His actions contributed directly to the successful completion of the operation.",
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.getByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).toBeVisible();
+
+    const narrativeField = screen.getByRole("textbox", {
+      name: "Narrative",
+    });
+
+    await user.clear(narrativeField);
+    await user.type(
+      narrativeField,
+      "Specialist John Smith maintained the defensive position throughout the operation. " +
+        "He repeatedly engaged enemy forces during each major contact. " +
+        "His actions contributed directly to the successful completion of the operation.",
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.queryByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText("Citation Narrative").querySelector("mark"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows no narrative warnings for compliant narrative text", async () => {
+    const user = userEvent.setup();
+
+    await renderMedalRecommendationAid();
+
+    await completeRecommendation(
+      user,
+      "Specialist John Smith maintained the defensive position throughout the operation. " +
+        "He repeatedly engaged enemy forces during each major contact. " +
+        "His actions contributed directly to the successful completion of the operation.",
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Generate Recommendation",
+      }),
+    );
+
+    expect(
+      screen.queryByRole("status", {
+        name: "Narrative Warnings",
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText("Citation Narrative").querySelector("mark"),
+    ).not.toBeInTheDocument();
   });
 
   test("prevents generation when no recipient is selected", async () => {
@@ -1202,7 +1274,7 @@ describe("Medal Recommendation Aid", () => {
       screen.getByRole("textbox", {
         name: "Narrative",
       }),
-      "SPC Smith maintained the position throughout the operation.",
+      "Specialist John Smith maintained the position throughout the operation.",
     );
 
     await user.click(
@@ -1353,7 +1425,7 @@ describe("Medal Recommendation Aid", () => {
 
     await completeRecommendation(
       user,
-      "SPC Smith maintained the position throughout the operation.",
+      "Specialist John Smith maintained the position throughout the operation.",
       {
         omit: "combatElement",
       },
@@ -1390,7 +1462,7 @@ describe("Medal Recommendation Aid", () => {
 
     await completeRecommendation(
       user,
-      "SPC Smith maintained the position throughout the operation.",
+      "Specialist John Smith maintained the position throughout the operation.",
       {
         omit: "operationTitle",
       },
@@ -1427,7 +1499,7 @@ describe("Medal Recommendation Aid", () => {
 
     await completeRecommendation(
       user,
-      "SPC Smith maintained the position throughout the operation.",
+      "Specialist John Smith maintained the position throughout the operation.",
       {
         omit: "location",
       },
@@ -1490,19 +1562,22 @@ describe("Medal Recommendation Aid", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("normalizes an explicit full-rank full-roster-name first mention and later references", async () => {
+  test("prevents generation when Operation Date is in the future", async () => {
     const user = userEvent.setup();
 
     await renderMedalRecommendationAid();
 
-    const narrative =
-      "Specialist Taylor Morgan Smith established the defensive position. " +
-      "Taylor Smith maintained control through the final engagement.";
+    await completeRecommendation(
+      user,
+      "Specialist John Smith maintained the defensive position throughout the operation. " +
+        "He repeatedly engaged enemy forces during each major contact. " +
+        "His actions contributed directly to the successful completion of the operation.",
+      {
+        omit: "operationDate",
+      },
+    );
 
-    await completeRecommendation(user, narrative, {
-      recipientQuery: "Smi",
-      recipientUsername: "Smith.TM",
-    });
+    await user.type(screen.getByLabelText("Operation Date"), "2099-01-01");
 
     await user.click(
       screen.getByRole("button", {
@@ -1510,110 +1585,131 @@ describe("Medal Recommendation Aid", () => {
       }),
     );
 
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    const expectedCitation =
-      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
-      "Specialist Taylor Smith established the defensive position. " +
-      "Specialist Smith maintained control through the final engagement. " +
-      "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
-
-    expect(citation.textContent).toBe(expectedCitation);
-  });
-
-  test("normalizes the first recipient mention without requiring matching capitalization", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "spc smith maintained the defensive position. " +
-      "Smith continued to support the squad.";
-
-    await completeRecommendation(user, narrative);
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
+    expect(screen.getByLabelText("Operation Date")).toHaveAttribute(
+      "aria-invalid",
+      "true",
     );
 
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    const expectedCitation =
-      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
-      "Specialist John Smith maintained the defensive position. " +
-      "Specialist Smith continued to support the squad. " +
-      "Specialist John Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
-
-    expect(citation.textContent).toBe(expectedCitation);
-  });
-
-  test("does not treat regex characters in a roster name as wildcard matches", async () => {
-    const user = userEvent.setup();
-
-    await renderMedalRecommendationAid();
-
-    const narrative =
-      "Specialist Taylor JX Smith maintained the defensive position throughout the operation.";
-
-    await completeRecommendation(user, narrative, {
-      recipientQuery: "Smi",
-      recipientUsername: "Smith.TJ",
-    });
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /complete all required fields before generating a recommendation/i,
     );
-
-    const citation = screen.getByLabelText("Citation Narrative");
-
-    const expectedCitation =
-      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
-      "Specialist Taylor JX Smith maintained the defensive position throughout the operation. " +
-      "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
-
-    expect(citation.textContent).toBe(expectedCitation);
-    expect(citation.querySelector("mark")).not.toBeInTheDocument();
 
     expect(
-      screen.queryByRole("status", {
-        name: "Formatting Adjustments",
+      screen.queryByRole("region", {
+        name: "Recommendation Preview",
       }),
     ).not.toBeInTheDocument();
   });
 
-  test("normalizes a first mention containing regex characters in the roster name", async () => {
+  test("treats tomorrow in the user's local timezone as a future Operation Date", async () => {
+    const originalTimezone = process.env.TZ;
     const user = userEvent.setup();
 
-    await renderMedalRecommendationAid();
+    process.env.TZ = "America/Los_Angeles";
 
-    const narrative =
-      "Specialist Taylor J. Smith maintained the defensive position throughout the operation. " +
-      "Taylor Smith continued to support the squad.";
+    try {
+      await renderMedalRecommendationAid();
 
-    await completeRecommendation(user, narrative, {
-      recipientQuery: "Smi",
-      recipientUsername: "Smith.TJ",
-    });
+      await completeRecommendation(
+        user,
+        "Specialist John Smith maintained the defensive position throughout the operation. " +
+          "He repeatedly engaged enemy forces during each major contact. " +
+          "His actions contributed directly to the successful completion of the operation.",
+        {
+          omit: "operationDate",
+        },
+      );
 
-    await user.click(
-      screen.getByRole("button", {
-        name: "Generate Recommendation",
-      }),
-    );
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-15T03:30:00.000Z"));
 
-    const citation = screen.getByLabelText("Citation Narrative");
+      fireEvent.change(screen.getByLabelText("Operation Date"), {
+        target: { value: "2026-08-15" },
+      });
 
-    const expectedCitation =
-      "For skillful actions over an entire operation while serving as rifleman in the 7th Cavalry Regiment during combat in Operation Exfor near Remagen on 11 August 2026. " +
-      "Specialist Taylor Smith maintained the defensive position throughout the operation. " +
-      "Specialist Smith continued to support the squad. " +
-      "Specialist Taylor Smith's skillful actions reflect great credit upon themselves and the 7th Cavalry Gaming Regiment.";
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Generate Recommendation",
+        }),
+      );
 
-    expect(citation.textContent).toBe(expectedCitation);
+      expect(screen.getByLabelText("Operation Date")).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /complete all required fields before generating a recommendation/i,
+      );
+
+      expect(
+        screen.queryByRole("region", {
+          name: "Recommendation Preview",
+        }),
+      ).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+
+      if (originalTimezone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTimezone;
+      }
+    }
+  });
+
+  test("allows generation when Operation Date is today in the user's local timezone", async () => {
+    const originalTimezone = process.env.TZ;
+    const user = userEvent.setup();
+
+    process.env.TZ = "America/Los_Angeles";
+
+    try {
+      await renderMedalRecommendationAid();
+
+      await completeRecommendation(
+        user,
+        "Specialist John Smith maintained the defensive position throughout the operation. " +
+          "He repeatedly engaged enemy forces during each major contact. " +
+          "His actions contributed directly to the successful completion of the operation.",
+        {
+          omit: "operationDate",
+        },
+      );
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-15T03:30:00.000Z"));
+
+      fireEvent.change(screen.getByLabelText("Operation Date"), {
+        target: { value: "2026-08-14" },
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Generate Recommendation",
+        }),
+      );
+
+      expect(screen.getByLabelText("Operation Date")).not.toHaveAttribute(
+        "aria-invalid",
+      );
+
+      expect(
+        screen.getByRole("region", {
+          name: "Recommendation Preview",
+        }),
+      ).toBeVisible();
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+
+      if (originalTimezone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTimezone;
+      }
+    }
   });
 
   test("trims valid text fields before generating the citation", async () => {
@@ -1662,7 +1758,7 @@ describe("Medal Recommendation Aid", () => {
       screen.getByRole("textbox", {
         name: "Narrative",
       }),
-      "  SPC Smith maintained the position throughout the operation.  ",
+      "  Specialist John Smith maintained the position throughout the operation.  ",
     );
 
     await user.click(
@@ -1688,7 +1784,7 @@ describe("Medal Recommendation Aid", () => {
 
     await completeRecommendation(
       user,
-      "SPC Smith maintained the position throughout the operation.",
+      "Specialist John Smith maintained the position throughout the operation.",
     );
 
     await user.click(
@@ -1712,7 +1808,7 @@ describe("Medal Recommendation Aid", () => {
     await renderMedalRecommendationAid();
 
     const narrative =
-      "SPC Smith maintained an effective fighting position throughout the operation. " +
+      "Specialist John Smith maintained an effective fighting position throughout the operation. " +
       "He repeatedly engaged enemy forces and supported his squad during each major contact. " +
       "His performance contributed directly to the successful completion of the operation.";
 
@@ -1741,7 +1837,7 @@ describe("Medal Recommendation Aid", () => {
     await renderMedalRecommendationAid();
 
     const narrative =
-      "SPC Smith maintained an effective fighting position throughout the operation. " +
+      "Specialist John Smith maintained an effective fighting position throughout the operation. " +
       "He repeatedly engaged enemy forces and supported his squad during each major contact. " +
       "His performance contributed directly to the successful completion of the operation.";
 

--- a/client/app/reusableModules/getMedalRecipientRoster.jsx
+++ b/client/app/reusableModules/getMedalRecipientRoster.jsx
@@ -1,0 +1,17 @@
+const CLIENT_TOKEN = process.env.NEXT_PUBLIC_CLIENT_TOKEN;
+const MEDAL_RECIPIENT_API_URL = process.env.MEDAL_RECIPIENT_API_URL;
+
+export default async function GetMedalRecipientRoster() {
+  const response = await fetch(MEDAL_RECIPIENT_API_URL, {
+    headers: {
+      Authorization: CLIENT_TOKEN,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("HTTP Error! status: " + response.status);
+  }
+
+  return await response.json();
+}

--- a/client/vitest.setup.js
+++ b/client/vitest.setup.js
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 process.env.COMBAT_API_URL = "https://combat-roster.test/";
+process.env.MEDAL_RECIPIENT_API_URL = "https://medal-recipient-roster.test/";
 
 process.env.NEXT_PUBLIC_CLIENT_TOKEN = "test-client-token";
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# CavApps stack — builds the server and client from source so your local changes
+# CavApps stack â€” builds the server and client from source so your local changes
 # are what runs. The client is bind-mounted and hot-reloads; the server is baked
 # into its image at build time, so server changes need a rebuild (--build), not
 # just a restart. For local development always layer the dev override on top:
@@ -13,7 +13,7 @@
 services:
   # Postgres backs the roster-history diff store and the user-search cache.
   # The server runs its migrations on startup and will not boot until this is
-  # reachable, so it comes up first as part of the stack — no setup required.
+  # reachable, so it comes up first as part of the stack â€” no setup required.
   postgres:
     image: postgres:16-alpine
     container_name: cavapps-postgres
@@ -94,6 +94,7 @@ services:
       # server over the internal Docker network.
       COMBAT_API_URL: http://server:4000/roster/combat
       RESERVE_API_URL: http://server:4000/roster/reserves
+      MEDAL_RECIPIENT_API_URL: http://server:4000/roster/medal-recipients
       CACHE_TIMESTAMP_URL: http://server:4000/cache-timestamp
       GROUP_API_URL: http://server:4000/roster/groups
       # NEXT_PUBLIC_* values are baked into the browser bundle, so they must point

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# CavApps stack â€” builds the server and client from source so your local changes
+# CavApps stack - builds the server and client from source so your local changes
 # are what runs. The client is bind-mounted and hot-reloads; the server is baked
 # into its image at build time, so server changes need a rebuild (--build), not
 # just a restart. For local development always layer the dev override on top:
@@ -13,7 +13,7 @@
 services:
   # Postgres backs the roster-history diff store and the user-search cache.
   # The server runs its migrations on startup and will not boot until this is
-  # reachable, so it comes up first as part of the stack â€” no setup required.
+  # reachable, so it comes up first as part of the stack - no setup required.
   postgres:
     image: postgres:16-alpine
     container_name: cavapps-postgres

--- a/server/controllers/cacheManager.js
+++ b/server/controllers/cacheManager.js
@@ -68,6 +68,7 @@ const updateReserveRosterCache = async () => {
 const updateMedalRecipientRosterCache = async () => {
   try {
     const requestOptions = {
+      timeout: 5000,
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
@@ -176,10 +177,6 @@ const initializeCache = async () => {
     await updateReserveRosterCache();
     await updateCachedGroups();
 
-    // Medal Recommendation recipient data is useful to the Medal Aid,
-    // but it is not a startup-critical dependency for the rest of CavApps.
-    await updateMedalRecipientRosterCache();
-
     // Check only the existing startup-critical caches.
     if (
       !cacheStatus["combat"] ||
@@ -189,6 +186,11 @@ const initializeCache = async () => {
       console.error("Failed to initialize cache. Exiting...");
       process.exit(1); // Exit to trigger Docker restart
     }
+
+    // Medal Recommendation recipient data is useful to the Medal Aid,
+    // but it is not a startup-critical dependency for the rest of CavApps.
+    // Start the initial refresh without delaying server startup.
+    void updateMedalRecipientRosterCache();
 
     // Schedule the updates
     scheduleCacheUpdate(updateCombatRosterCache);

--- a/server/controllers/cacheManager.js
+++ b/server/controllers/cacheManager.js
@@ -1,5 +1,7 @@
 const axios = require("axios");
 const axiosRetry = require("axios-retry").default || require("axios-retry");
+const { filterRetiredRoster } = require("./rosterFilters");
+
 const API_TOKEN = process.env.API_TOKEN;
 
 let cacheStatus = {
@@ -7,12 +9,14 @@ let cacheStatus = {
   reserve: false,
   individual: false,
   groups: false,
+  medalRecipients: false,
 };
 
 let cachedCombatRoster;
 let cachedReserveRoster;
 let cachedIndividual;
 let cachedGroups;
+let cachedMedalRecipientRoster;
 let cacheTime = {};
 
 axiosRetry(axios, {
@@ -61,6 +65,51 @@ const updateReserveRosterCache = async () => {
   }
 };
 
+const updateMedalRecipientRosterCache = async () => {
+  try {
+    const requestOptions = {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + API_TOKEN,
+        "Accept-Encoding": "gzip",
+      },
+    };
+
+    const [
+      combatResponse,
+      reserveResponse,
+      eloaResponse,
+      wallOfHonorResponse,
+      pastMembersResponse,
+    ] = await Promise.all([
+      axios("https://api.7cav.us/api/v1/roster/1/lite", requestOptions),
+      axios("https://api.7cav.us/api/v1/roster/2/lite", requestOptions),
+      axios("https://api.7cav.us/api/v1/roster/3/lite", requestOptions),
+      axios("https://api.7cav.us/api/v1/roster/4/lite", requestOptions),
+      axios("https://api.7cav.us/api/v1/roster/6/lite", requestOptions),
+    ]);
+
+    const retiredResponse = filterRetiredRoster(pastMembersResponse.data);
+
+    cachedMedalRecipientRoster = {
+      profiles: {
+        ...(combatResponse.data?.profiles ?? {}),
+        ...(reserveResponse.data?.profiles ?? {}),
+        ...(eloaResponse.data?.profiles ?? {}),
+        ...(wallOfHonorResponse.data?.profiles ?? {}),
+        ...(retiredResponse.profiles ?? {}),
+      },
+    };
+
+    cacheTime["medalRecipients"] = Date.now();
+    cacheStatus.medalRecipients = true;
+  } catch (error) {
+    console.error("Failed to update Medal recipient cache:", error.message);
+    cacheStatus.medalRecipients = false;
+  }
+};
+
 const updateCachedIndividual = async (userName) => {
   try {
     const response = await axios(
@@ -88,7 +137,7 @@ const updateCachedIndividual = async (userName) => {
 const updateCachedGroups = async () => {
   try {
     const response = await axios(
-      `https://api.7cav.us/api/v1/milpacs/position/groups`,
+      "https://api.7cav.us/api/v1/milpacs/position/groups",
       {
         headers: {
           Accept: "application/json",
@@ -127,7 +176,11 @@ const initializeCache = async () => {
     await updateReserveRosterCache();
     await updateCachedGroups();
 
-    // Check if cache is valid
+    // Medal Recommendation recipient data is useful to the Medal Aid,
+    // but it is not a startup-critical dependency for the rest of CavApps.
+    await updateMedalRecipientRosterCache();
+
+    // Check only the existing startup-critical caches.
     if (
       !cacheStatus["combat"] ||
       !cacheStatus["reserve"] ||
@@ -141,6 +194,7 @@ const initializeCache = async () => {
     scheduleCacheUpdate(updateCombatRosterCache);
     scheduleCacheUpdate(updateReserveRosterCache);
     scheduleCacheUpdate(updateCachedGroups);
+    scheduleCacheUpdate(updateMedalRecipientRosterCache);
   } catch (error) {
     // Fatal path: keep the stack, which is the only diagnostic before exit.
     // Never the error object itself — that is what carried the token.
@@ -160,6 +214,10 @@ const getCachedReserveRoster = () => {
   return cachedReserveRoster;
 };
 
+const getCachedMedalRecipientRoster = () => {
+  return cachedMedalRecipientRoster;
+};
+
 const getCachedIndividual = () => {
   return cachedIndividual;
 };
@@ -170,8 +228,10 @@ const getCachedGroups = () => {
 
 module.exports = {
   updateCachedIndividual,
+  updateMedalRecipientRosterCache,
   getCachedCombatRoster,
   getCachedReserveRoster,
+  getCachedMedalRecipientRoster,
   getCachedIndividual,
   getCachedGroups,
   cacheTime,

--- a/server/controllers/mRequest.js
+++ b/server/controllers/mRequest.js
@@ -1,0 +1,12 @@
+const cacheManager = require("../controllers/cacheManager");
+
+module.exports = async (req, res) => {
+  const cachedMedalRecipientRoster =
+    cacheManager.getCachedMedalRecipientRoster();
+
+  if (cachedMedalRecipientRoster) {
+    res.send(cachedMedalRecipientRoster);
+  } else {
+    res.status(503).send("Cache is empty");
+  }
+};

--- a/server/controllers/medalRecipientCache.test.js
+++ b/server/controllers/medalRecipientCache.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const assert = require("assert");
+const axios = require("axios");
 const dns = require("dns");
 const http = require("http");
 const net = require("net");
@@ -244,6 +245,22 @@ const main = async () => {
 
   const restoreNetwork = redirectUpstreamTo(port);
 
+  const medalRequestConfigs = [];
+
+  const interceptorId = axios.interceptors.request.use((config) => {
+    if (
+      config.url?.includes("/api/v1/roster/") &&
+      config.url.endsWith("/lite")
+    ) {
+      medalRequestConfigs.push({
+        url: config.url,
+        timeout: config.timeout,
+      });
+    }
+
+    return config;
+  });
+
   try {
     await cacheManager.updateMedalRecipientRosterCache();
 
@@ -264,6 +281,19 @@ const main = async () => {
         "/api/v1/roster/6/lite",
       ],
       "expected all five required lite rosters to be fetched",
+    );
+
+    assert.strictEqual(
+      medalRequestConfigs.length,
+      5,
+      "expected to inspect all five Medal recipient roster requests",
+    );
+
+    assert.ok(
+      medalRequestConfigs.every(
+        ({ timeout }) => Number.isFinite(timeout) && timeout > 0,
+      ),
+      "expected every Medal recipient roster request to have a finite timeout",
     );
 
     assert.ok(
@@ -327,6 +357,7 @@ const main = async () => {
       "cacheManager: Medal recipient roster includes supported recipient pools only — OK",
     );
   } finally {
+    axios.interceptors.request.eject(interceptorId);
     restoreNetwork();
 
     await new Promise((resolve) => {

--- a/server/controllers/medalRecipientCache.test.js
+++ b/server/controllers/medalRecipientCache.test.js
@@ -1,0 +1,341 @@
+"use strict";
+
+const assert = require("assert");
+const dns = require("dns");
+const http = require("http");
+const net = require("net");
+const tls = require("tls");
+
+const SENTINEL = "SENTINEL-MEDAL-RECIPIENT-TOKEN";
+
+// cacheManager reads API_TOKEN when it is first required.
+process.env.API_TOKEN = SENTINEL;
+
+const cacheManager = require("./cacheManager");
+
+const rosterResponses = {
+  "/api/v1/roster/1/lite": {
+    profiles: {
+      1001: {
+        user: {
+          userId: "1001",
+          username: "Combat.C",
+        },
+        rank: {
+          rankShort: "SPC",
+          rankFull: "Specialist",
+        },
+        realName: "Casey Combat",
+        roster: "ROSTER_TYPE_COMBAT",
+        primary: {
+          positionTitle: "Trooper",
+        },
+      },
+    },
+  },
+
+  "/api/v1/roster/2/lite": {
+    profiles: {
+      1002: {
+        user: {
+          userId: "1002",
+          username: "Reserve.R",
+        },
+        rank: {
+          rankShort: "SGT",
+          rankFull: "Sergeant",
+        },
+        realName: "Riley Reserve",
+        roster: "ROSTER_TYPE_RESERVE",
+        primary: {
+          positionTitle: "Reservist",
+        },
+      },
+    },
+  },
+
+  "/api/v1/roster/3/lite": {
+    profiles: {
+      1003: {
+        user: {
+          userId: "1003",
+          username: "Eloa.E",
+        },
+        rank: {
+          rankShort: "CPL",
+          rankFull: "Corporal",
+        },
+        realName: "Elliot Eloa",
+        roster: "ROSTER_TYPE_ELOA",
+        primary: {
+          positionTitle: "ELOA",
+        },
+      },
+    },
+  },
+
+  "/api/v1/roster/4/lite": {
+    profiles: {
+      1004: {
+        user: {
+          userId: "1004",
+          username: "Honor.H",
+        },
+        rank: {
+          rankShort: "1SG",
+          rankFull: "First Sergeant",
+        },
+        realName: "Harper Honor",
+        roster: "ROSTER_TYPE_WALL_OF_HONOR",
+        primary: {
+          positionTitle: "Wall of Honor",
+        },
+      },
+    },
+  },
+
+  "/api/v1/roster/6/lite": {
+    profiles: {
+      1005: {
+        user: {
+          userId: "1005",
+          username: "Retired.R",
+        },
+        rank: {
+          rankShort: "MAJ",
+          rankFull: "Major",
+        },
+        realName: "Robin Retired",
+        roster: "ROSTER_TYPE_PAST_MEMBERS",
+        primary: {
+          positionTitle: "Retired",
+        },
+      },
+
+      1006: {
+        user: {
+          userId: "1006",
+          username: "Discharged.D",
+        },
+        rank: {
+          rankShort: "CPL",
+          rankFull: "Corporal",
+        },
+        realName: "Dana Discharged",
+        roster: "ROSTER_TYPE_PAST_MEMBERS",
+        primary: {
+          positionTitle: "Discharged",
+        },
+      },
+
+      1007: {
+        user: {
+          userId: "1007",
+          username: "Dishonorable.D",
+        },
+        rank: {
+          rankShort: "PVT",
+          rankFull: "Private",
+        },
+        realName: "Drew Dishonorable",
+        roster: "ROSTER_TYPE_PAST_MEMBERS",
+        primary: {
+          positionTitle: "Dishonorably Discharged",
+        },
+      },
+    },
+  },
+};
+
+const startStub = async () => {
+  const requestsSeen = [];
+  const authHeadersSeen = [];
+
+  const server = http.createServer((req, res) => {
+    requestsSeen.push(req.url);
+    authHeadersSeen.push(req.headers.authorization);
+
+    const response = rosterResponses[req.url];
+
+    if (!response) {
+      res.writeHead(404, {
+        "Content-Type": "application/json",
+      });
+
+      res.end('{"error":"not found"}');
+      return;
+    }
+
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+    });
+
+    res.end(JSON.stringify(response));
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  return {
+    server,
+    port: server.address().port,
+    requestsSeen,
+    authHeadersSeen,
+  };
+};
+
+const redirectUpstreamTo = (port) => {
+  const realLookup = dns.lookup;
+  const realConnect = tls.connect;
+
+  dns.lookup = function (hostname, options, callback) {
+    if (hostname !== "api.7cav.us") {
+      return realLookup.apply(this, arguments);
+    }
+
+    if (typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+
+    return options && options.all
+      ? callback(null, [
+          {
+            address: "127.0.0.1",
+            family: 4,
+          },
+        ])
+      : callback(null, "127.0.0.1", 4);
+  };
+
+  tls.connect = function (options, callback) {
+    if (!options || Number(options.port) !== 443) {
+      return realConnect.call(this, options, callback);
+    }
+
+    const socket = net.connect(port, "127.0.0.1");
+
+    socket.on("connect", () => {
+      socket.authorized = true;
+      socket.encrypted = true;
+      socket.getPeerCertificate = () => ({});
+      socket.getSession = () => undefined;
+      socket.getProtocol = () => "TLSv1.3";
+      socket.isSessionReused = () => false;
+      socket.emit("secureConnect");
+    });
+
+    if (typeof callback === "function") {
+      socket.once("secureConnect", callback);
+    }
+
+    return socket;
+  };
+
+  return () => {
+    dns.lookup = realLookup;
+    tls.connect = realConnect;
+  };
+};
+
+const main = async () => {
+  const { server, port, requestsSeen, authHeadersSeen } = await startStub();
+
+  const restoreNetwork = redirectUpstreamTo(port);
+
+  try {
+    await cacheManager.updateMedalRecipientRosterCache();
+
+    const result = cacheManager.getCachedMedalRecipientRoster();
+
+    assert.ok(
+      result,
+      "expected a cached Medal Recommendation recipient roster",
+    );
+
+    assert.deepStrictEqual(
+      [...requestsSeen].sort(),
+      [
+        "/api/v1/roster/1/lite",
+        "/api/v1/roster/2/lite",
+        "/api/v1/roster/3/lite",
+        "/api/v1/roster/4/lite",
+        "/api/v1/roster/6/lite",
+      ],
+      "expected all five required lite rosters to be fetched",
+    );
+
+    assert.ok(
+      authHeadersSeen.every((header) => header === `Bearer ${SENTINEL}`),
+      "expected every roster request to use the configured API token",
+    );
+
+    assert.deepStrictEqual(
+      Object.keys(result.profiles).sort(),
+      ["1001", "1002", "1003", "1004", "1005"],
+      "expected Combat, Reserve, ELOA, Wall of Honor, and Retired recipients only",
+    );
+
+    assert.strictEqual(
+      result.profiles["1001"].roster,
+      "ROSTER_TYPE_COMBAT",
+      "expected Combat roster status to be preserved",
+    );
+
+    assert.strictEqual(
+      result.profiles["1002"].roster,
+      "ROSTER_TYPE_RESERVE",
+      "expected Reserve roster status to be preserved",
+    );
+
+    assert.strictEqual(
+      result.profiles["1003"].roster,
+      "ROSTER_TYPE_ELOA",
+      "expected ELOA roster status to be preserved",
+    );
+
+    assert.strictEqual(
+      result.profiles["1004"].roster,
+      "ROSTER_TYPE_WALL_OF_HONOR",
+      "expected Wall of Honor roster status to be preserved",
+    );
+
+    assert.strictEqual(
+      result.profiles["1005"].roster,
+      "ROSTER_TYPE_PAST_MEMBERS",
+      "expected Retired members to preserve the Past Members roster status",
+    );
+
+    assert.strictEqual(
+      result.profiles["1005"].primary.positionTitle,
+      "Retired",
+      "expected the Retired classification to be preserved",
+    );
+
+    assert.ok(
+      !result.profiles["1006"],
+      "expected Discharged Past Members to be excluded",
+    );
+
+    assert.ok(
+      !result.profiles["1007"],
+      "expected Dishonorably Discharged Past Members to be excluded",
+    );
+
+    console.log(
+      "cacheManager: Medal recipient roster includes supported recipient pools only — OK",
+    );
+  } finally {
+    restoreNetwork();
+
+    await new Promise((resolve) => {
+      server.close(resolve);
+    });
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/server/controllers/medalRecipientInitialization.test.js
+++ b/server/controllers/medalRecipientInitialization.test.js
@@ -13,6 +13,12 @@ process.env.API_TOKEN = SENTINEL;
 
 const startStub = async () => {
   const requestsSeen = [];
+  const pendingMedalResponses = [];
+
+  let resolveMedalRequestStarted;
+  const medalRequestStarted = new Promise((resolve) => {
+    resolveMedalRequestStarted = resolve;
+  });
 
   const server = http.createServer((req, res) => {
     requestsSeen.push(req.url);
@@ -36,9 +42,8 @@ const startStub = async () => {
       return;
     }
 
-    // The Medal-specific roster calls deliberately fail.
-    // This simulates the Medal recipient source being unavailable while
-    // the rest of CavApps' required cache sources remain healthy.
+    // Medal-specific roster requests deliberately remain pending.
+    // initializeCache must be able to finish without waiting for them.
     if (
       req.url === "/api/v1/roster/1/lite" ||
       req.url === "/api/v1/roster/2/lite" ||
@@ -46,8 +51,8 @@ const startStub = async () => {
       req.url === "/api/v1/roster/4/lite" ||
       req.url === "/api/v1/roster/6/lite"
     ) {
-      res.writeHead(401, { "Content-Type": "application/json" });
-      res.end('{"error":"medal recipient source unavailable"}');
+      resolveMedalRequestStarted();
+      pendingMedalResponses.push(res);
       return;
     }
 
@@ -63,6 +68,13 @@ const startStub = async () => {
     server,
     port: server.address().port,
     requestsSeen,
+    medalRequestStarted,
+    releaseMedalRequests() {
+      for (const res of pendingMedalResponses.splice(0)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end('{"error":"medal recipient source unavailable"}');
+      }
+    },
   };
 };
 
@@ -121,7 +133,13 @@ const redirectUpstreamTo = (port) => {
 };
 
 const main = async () => {
-  const { server, port, requestsSeen } = await startStub();
+  const {
+    server,
+    port,
+    requestsSeen,
+    medalRequestStarted,
+    releaseMedalRequests,
+  } = await startStub();
 
   const restoreNetwork = redirectUpstreamTo(port);
 
@@ -130,22 +148,39 @@ const main = async () => {
   const realSetTimeout = global.setTimeout;
   global.setTimeout = () => 1;
 
-  // A Medal cache failure must not reach process.exit.
+  // A Medal cache problem must not reach process.exit.
   const realExit = process.exit;
   let exitCalled = false;
 
   process.exit = () => {
     exitCalled = true;
     throw new Error(
-      "process.exit must not be called for a Medal recipient cache failure",
+      "process.exit must not be called for a Medal recipient cache problem",
     );
   };
 
   // Require after API_TOKEN and test seams are configured.
   const cacheManager = require("./cacheManager");
 
+  let initializationPromise;
+
   try {
-    await cacheManager.initializeCache();
+    initializationPromise = cacheManager.initializeCache();
+
+    // Startup-critical cache initialization must finish even though the
+    // Medal recipient requests are still pending.
+    await Promise.race([
+      initializationPromise,
+      new Promise((_, reject) => {
+        realSetTimeout(() => {
+          reject(
+            new Error(
+              "initializeCache waited for the Medal recipient cache to finish",
+            ),
+          );
+        }, 1000);
+      }),
+    ]);
 
     assert.ok(
       requestsSeen.includes("/api/v1/roster/1"),
@@ -162,27 +197,50 @@ const main = async () => {
       "expected the existing Groups cache to initialize",
     );
 
-    assert.ok(
-      requestsSeen.includes("/api/v1/roster/1/lite"),
-      "expected initialization to attempt the Medal recipient cache",
-    );
+    // The initial Medal refresh should still be started; it simply must not
+    // block the startup-critical initialization path.
+    await Promise.race([
+      medalRequestStarted,
+      new Promise((_, reject) => {
+        realSetTimeout(() => {
+          reject(
+            new Error(
+              "expected initialization to start the Medal recipient cache refresh",
+            ),
+          );
+        }, 500);
+      }),
+    ]);
 
     assert.strictEqual(
       exitCalled,
       false,
-      "expected a Medal recipient cache failure not to terminate CavApps",
+      "expected a pending Medal recipient cache not to terminate CavApps",
     );
 
     assert.strictEqual(
       cacheManager.getCachedMedalRecipientRoster(),
       undefined,
-      "expected the unavailable Medal recipient cache to remain unavailable",
+      "expected initializeCache to finish while the Medal recipient cache is still pending",
     );
 
     console.log(
-      "cacheManager: Medal recipient initialization failure is non-fatal — OK",
+      "cacheManager: Medal recipient initialization does not block startup - OK",
     );
   } finally {
+    // Release any deliberately hanging requests before restoring the real
+    // timers/network so the test does not leave open sockets behind.
+    releaseMedalRequests();
+
+    if (initializationPromise) {
+      try {
+        await initializationPromise;
+      } catch {
+        // Cleanup only. Any meaningful failure is reported by the assertions
+        // above or by initializeCache's own fatal path.
+      }
+    }
+
     process.exit = realExit;
     global.setTimeout = realSetTimeout;
     restoreNetwork();

--- a/server/controllers/medalRecipientInitialization.test.js
+++ b/server/controllers/medalRecipientInitialization.test.js
@@ -1,0 +1,199 @@
+"use strict";
+
+const assert = require("assert");
+const dns = require("dns");
+const http = require("http");
+const net = require("net");
+const tls = require("tls");
+
+const SENTINEL = "SENTINEL-MEDAL-INIT-TOKEN";
+
+// cacheManager reads API_TOKEN when the module is loaded.
+process.env.API_TOKEN = SENTINEL;
+
+const startStub = async () => {
+  const requestsSeen = [];
+
+  const server = http.createServer((req, res) => {
+    requestsSeen.push(req.url);
+
+    // Existing startup-critical caches succeed.
+    if (req.url === "/api/v1/roster/1") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"profiles":{}}');
+      return;
+    }
+
+    if (req.url === "/api/v1/roster/2") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"profiles":{}}');
+      return;
+    }
+
+    if (req.url === "/api/v1/milpacs/position/groups") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"groups":[]}');
+      return;
+    }
+
+    // The Medal-specific roster calls deliberately fail.
+    // This simulates the Medal recipient source being unavailable while
+    // the rest of CavApps' required cache sources remain healthy.
+    if (
+      req.url === "/api/v1/roster/1/lite" ||
+      req.url === "/api/v1/roster/2/lite" ||
+      req.url === "/api/v1/roster/3/lite" ||
+      req.url === "/api/v1/roster/4/lite" ||
+      req.url === "/api/v1/roster/6/lite"
+    ) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end('{"error":"medal recipient source unavailable"}');
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end('{"error":"not found"}');
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  return {
+    server,
+    port: server.address().port,
+    requestsSeen,
+  };
+};
+
+const redirectUpstreamTo = (port) => {
+  const realLookup = dns.lookup;
+  const realConnect = tls.connect;
+
+  dns.lookup = function (hostname, options, callback) {
+    if (hostname !== "api.7cav.us") {
+      return realLookup.apply(this, arguments);
+    }
+
+    if (typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+
+    return options && options.all
+      ? callback(null, [
+          {
+            address: "127.0.0.1",
+            family: 4,
+          },
+        ])
+      : callback(null, "127.0.0.1", 4);
+  };
+
+  tls.connect = function (options, callback) {
+    if (!options || Number(options.port) !== 443) {
+      return realConnect.call(this, options, callback);
+    }
+
+    const socket = net.connect(port, "127.0.0.1");
+
+    socket.on("connect", () => {
+      socket.authorized = true;
+      socket.encrypted = true;
+      socket.getPeerCertificate = () => ({});
+      socket.getSession = () => undefined;
+      socket.getProtocol = () => "TLSv1.3";
+      socket.isSessionReused = () => false;
+      socket.emit("secureConnect");
+    });
+
+    if (typeof callback === "function") {
+      socket.once("secureConnect", callback);
+    }
+
+    return socket;
+  };
+
+  return () => {
+    dns.lookup = realLookup;
+    tls.connect = realConnect;
+  };
+};
+
+const main = async () => {
+  const { server, port, requestsSeen } = await startStub();
+
+  const restoreNetwork = redirectUpstreamTo(port);
+
+  // initializeCache normally schedules future refreshes. Suppress the real
+  // timers so this test can finish immediately.
+  const realSetTimeout = global.setTimeout;
+  global.setTimeout = () => 1;
+
+  // A Medal cache failure must not reach process.exit.
+  const realExit = process.exit;
+  let exitCalled = false;
+
+  process.exit = () => {
+    exitCalled = true;
+    throw new Error(
+      "process.exit must not be called for a Medal recipient cache failure",
+    );
+  };
+
+  // Require after API_TOKEN and test seams are configured.
+  const cacheManager = require("./cacheManager");
+
+  try {
+    await cacheManager.initializeCache();
+
+    assert.ok(
+      requestsSeen.includes("/api/v1/roster/1"),
+      "expected the existing Combat cache to initialize",
+    );
+
+    assert.ok(
+      requestsSeen.includes("/api/v1/roster/2"),
+      "expected the existing Reserve cache to initialize",
+    );
+
+    assert.ok(
+      requestsSeen.includes("/api/v1/milpacs/position/groups"),
+      "expected the existing Groups cache to initialize",
+    );
+
+    assert.ok(
+      requestsSeen.includes("/api/v1/roster/1/lite"),
+      "expected initialization to attempt the Medal recipient cache",
+    );
+
+    assert.strictEqual(
+      exitCalled,
+      false,
+      "expected a Medal recipient cache failure not to terminate CavApps",
+    );
+
+    assert.strictEqual(
+      cacheManager.getCachedMedalRecipientRoster(),
+      undefined,
+      "expected the unavailable Medal recipient cache to remain unavailable",
+    );
+
+    console.log(
+      "cacheManager: Medal recipient initialization failure is non-fatal — OK",
+    );
+  } finally {
+    process.exit = realExit;
+    global.setTimeout = realSetTimeout;
+    restoreNetwork();
+
+    await new Promise((resolve) => {
+      server.close(resolve);
+    });
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/server/controllers/rosterFilters.js
+++ b/server/controllers/rosterFilters.js
@@ -1,0 +1,23 @@
+"use strict";
+
+function filterRetiredRoster(rosterResponse) {
+  const profiles = rosterResponse?.profiles ?? {};
+
+  const retiredProfiles = Object.fromEntries(
+    Object.entries(profiles).filter(([, profile]) => {
+      return (
+        profile?.roster === "ROSTER_TYPE_PAST_MEMBERS" &&
+        profile?.primary?.positionTitle === "Retired"
+      );
+    }),
+  );
+
+  return {
+    ...rosterResponse,
+    profiles: retiredProfiles,
+  };
+}
+
+module.exports = {
+  filterRetiredRoster,
+};

--- a/server/controllers/rosterFilters.test.js
+++ b/server/controllers/rosterFilters.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const assert = require("assert");
+const { filterRetiredRoster } = require("./rosterFilters");
+
+const pastMembersResponse = {
+  profiles: {
+    1001: {
+      user: {
+        userId: "1001",
+        username: "Retired.R",
+      },
+      rank: {
+        rankShort: "SGT",
+        rankFull: "Sergeant",
+      },
+      realName: "Robert Retired",
+      roster: "ROSTER_TYPE_PAST_MEMBERS",
+      primary: {
+        positionTitle: "Retired",
+      },
+    },
+
+    1002: {
+      user: {
+        userId: "1002",
+        username: "Discharged.D",
+      },
+      rank: {
+        rankShort: "CPL",
+        rankFull: "Corporal",
+      },
+      realName: "Daniel Discharged",
+      roster: "ROSTER_TYPE_PAST_MEMBERS",
+      primary: {
+        positionTitle: "Discharged",
+      },
+    },
+
+    1003: {
+      user: {
+        userId: "1003",
+        username: "Dishonorable.D",
+      },
+      rank: {
+        rankShort: "PVT",
+        rankFull: "Private",
+      },
+      realName: "Donald Dishonorable",
+      roster: "ROSTER_TYPE_PAST_MEMBERS",
+      primary: {
+        positionTitle: "Dishonorably Discharged",
+      },
+    },
+
+    1004: {
+      user: {
+        userId: "1004",
+        username: "WrongRoster.R",
+      },
+      rank: {
+        rankShort: "SPC",
+        rankFull: "Specialist",
+      },
+      realName: "Walter Wrongroster",
+      roster: "ROSTER_TYPE_COMBAT",
+      primary: {
+        positionTitle: "Retired",
+      },
+    },
+  },
+};
+
+const result = filterRetiredRoster(pastMembersResponse);
+
+assert.deepStrictEqual(
+  Object.keys(result.profiles),
+  ["1001"],
+  "expected only Retired Past Members to remain",
+);
+
+assert.strictEqual(
+  result.profiles["1001"].user.username,
+  "Retired.R",
+  "expected the retired member to be preserved",
+);
+
+assert.strictEqual(
+  result.profiles["1001"].roster,
+  "ROSTER_TYPE_PAST_MEMBERS",
+  "expected the original roster type to be preserved",
+);
+
+assert.strictEqual(
+  result.profiles["1001"].primary.positionTitle,
+  "Retired",
+  "expected the Retired primary position to be preserved",
+);
+
+console.log("rosterFilters: only Retired Past Members are included — OK");

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript server for CavApps backend",
   "main": "index.js",
   "scripts": {
-    "test": "node controllers/cacheManager.test.js",
+    "test": "node controllers/cacheManager.test.js && node controllers/rosterFilters.test.js && node controllers/medalRecipientCache.test.js && node controllers/medalRecipientInitialization.test.js && node routes/medalRecipientRoute.test.js",
     "migrate": "node-pg-migrate up",
     "migrate:create": "node-pg-migrate create",
     "migrate:down": "node-pg-migrate down"

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const cors = require("cors");
 const cRequest = require("../controllers/cRequest");
 const rRequest = require("../controllers/rRequest");
+const mRequest = require("../controllers/mRequest");
 const iRequest = require("../controllers/iRequest");
 const gRequest = require("../controllers/gRequest");
 const app = express();
@@ -15,6 +16,7 @@ app.use(
 
 router.get("/combat", cRequest);
 router.get("/reserves", rRequest);
+router.get("/medal-recipients", mRequest);
 router.get("/individual", (req, res) => {
   const userName = req.query.username;
   if (!userName) {
@@ -23,4 +25,5 @@ router.get("/individual", (req, res) => {
   iRequest(req, res, userName);
 });
 router.get("/groups", gRequest);
+
 module.exports = router;

--- a/server/routes/medalRecipientRoute.test.js
+++ b/server/routes/medalRecipientRoute.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const assert = require("assert");
+
+const cacheManager = require("../controllers/cacheManager");
+
+const expectedRoster = {
+  profiles: {
+    1001: {
+      user: {
+        userId: "1001",
+        username: "Combat.C",
+      },
+      rank: {
+        rankShort: "SPC",
+        rankFull: "Specialist",
+      },
+      realName: "Casey Combat",
+      roster: "ROSTER_TYPE_COMBAT",
+      primary: {
+        positionTitle: "Trooper",
+      },
+    },
+
+    1002: {
+      user: {
+        userId: "1002",
+        username: "Reserve.R",
+      },
+      rank: {
+        rankShort: "SGT",
+        rankFull: "Sergeant",
+      },
+      realName: "Riley Reserve",
+      roster: "ROSTER_TYPE_RESERVE",
+      primary: {
+        positionTitle: "Reservist",
+      },
+    },
+  },
+};
+
+cacheManager.getCachedMedalRecipientRoster = () => expectedRoster;
+
+const router = require("./index");
+
+const routeLayer = router.stack.find(
+  (layer) =>
+    layer.route &&
+    layer.route.path === "/medal-recipients" &&
+    layer.route.methods.get,
+);
+
+assert.ok(routeLayer, "expected GET /medal-recipients to be registered");
+
+const handler = routeLayer.route.stack[0].handle;
+
+let statusCode = 200;
+let responseBody;
+
+const req = {};
+
+const res = {
+  status(code) {
+    statusCode = code;
+    return this;
+  },
+
+  send(body) {
+    responseBody = body;
+    return this;
+  },
+};
+
+const main = async () => {
+  await handler(req, res);
+
+  assert.strictEqual(
+    statusCode,
+    200,
+    "expected the Medal recipient endpoint to return HTTP 200",
+  );
+
+  assert.deepStrictEqual(
+    responseBody,
+    expectedRoster,
+    "expected the Medal recipient endpoint to return the cached recipient roster",
+  );
+
+  // An unavailable cache must fail clearly instead of returning an
+  // empty-looking roster that could be mistaken for valid data.
+  cacheManager.getCachedMedalRecipientRoster = () => undefined;
+
+  statusCode = 200;
+  responseBody = undefined;
+
+  await handler(req, res);
+
+  assert.strictEqual(
+    statusCode,
+    503,
+    "expected an unavailable Medal recipient cache to return HTTP 503",
+  );
+
+  assert.strictEqual(
+    responseBody,
+    "Cache is empty",
+    "expected the unavailable cache response to match the existing roster endpoint behavior",
+  );
+
+  console.log(
+    "routes: GET /medal-recipients returns cached data and reports unavailable cache — OK",
+  );
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
@SyniRon @Vercin-G 
Adds the next behavior slice for the Medal Recommendation Aid.

I originally planned to continue by adding the remaining Operation Medals, but I decided to change the sequence and strengthen the shared validation, recipient, and formatting behavior first before expanding the same workflow across additional medals.

This update adds required-field validation, recipient eligibility feedback, and automatic citation formatting corrections. The formatting corrections are limited to the points we discussed earlier in the week and are intended to remain in compliance with the SOP. Citation formatting adjustments are shown to the user with soft highlighting so no silent editing happens to the trooper’s own work, while the original narrative input remains unchanged. These additions are primarily intended to improve ease of use and make the recommendation process clearer for the user.

It also adds the CavApps server-side recipient roster cache required to support ELOA, Wall of Honor, and retired Past Members.

Testing includes client behavior tests, recipient eligibility tests, server cache/route tests, full project regression testing, build verification, Stryker mutation testing, and Docker smoke testing.

Once this review is approved I will move on to adding the rest of the operational medals.