### PR TITLE
fix(uniformbuilder): pick combat badges by family, not award priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ compose.yml
 # Tooling (do not commit)
 CLAUDE.md
 .claude/
+.playwright-mcp/
 docs/superpowers/
 .bmad/
 .bmad-core/

--- a/client/app/uniformbuilder/modules/AwardClasses.jsx
+++ b/client/app/uniformbuilder/modules/AwardClasses.jsx
@@ -1,10 +1,7 @@
 import {
   AwardAttachmentType,
-  MosGroup,
-  AwardNameFragment,
   hasValorDevice,
   stripValorDevice,
-  BadgeImages,
 } from "./constants";
 
 export class Award {
@@ -192,109 +189,30 @@ export class Badge extends Award {
   // Do things
 }
 
+// A member wears one combat badge: the highest-ranked of those they hold and
+// their MOS may display. Eligibility is settled before construction, in
+// getCanvasObject.jsx — every award reaching this class is one the member may
+// wear, so all that is left is to keep the highest.
 export class BadgeCombat extends Badge {
-  isMedical = false;
-  isAviation = false;
   imageNum = 0;
-  maxAllowed;
-  userMos = "";
 
-  constructor(awardData, userMos, AwardRegistry) {
+  constructor(awardData, AwardRegistry) {
     super(awardData, AwardRegistry);
 
     const registryDetails = AwardRegistry.getAwardDetails(awardData.awardName);
     this.awardPriority = registryDetails.awardPriority;
-
-    this.userMos = userMos;
-    if (MosGroup.AVIATION.includes(this.userMos)) {
-      this.isAviation = true;
-    }
-
-    if (MosGroup.MEDICAL.includes(this.userMos)) {
-      this.isMedical = true;
-    }
-
-    this.imageNum = this.getImageNum(this.awardPriority);
-    this.setMaxAllowed();
-  }
-
-  setMaxAllowed() {
-    if (this.isMedical) {
-      this.maxAllowed = 6;
-      return;
-    }
-
-    //we need to give 15T (aircrew) an exception so that they stop at aircrew badges.
-    if (this.isAviation) {
-      if (MosGroup.AIRCREW.includes(this.userMos)) {
-        this.maxAllowed = 8;
-      } else {
-        this.maxAllowed = 11;
-      }
-      return;
-    }
-
-    this.maxAllowed = 5;
-  }
-
-  getImageNum(awardPriority) {
-    // Maps awardPriority from constants/awardCatalog.js to a badge image that
-    // canvas.jsx will use to render from client/public/skunkworks/uniformBadges/combatBadges/<n>.png
-    // awardPriority values 1-5 (EIB thru CIB4) are universal and are matched by default and fall through
-
-    if (this.isAviation) {
-      switch (awardPriority) {
-        case 6:
-          return BadgeImages.aircrew;
-        case 7:
-          return BadgeImages.seniorAircrew;
-        case 8:
-          return BadgeImages.masterAircrew;
-        case 9:
-          return BadgeImages.aviator;
-        case 10:
-          return BadgeImages.seniorAviator;
-        case 11:
-          return BadgeImages.masterAviator;
-      }
-    }
-
-    // awardPriority 6 is used for both aviation and medical trees.
-    // isMedical will claim the value for the medical tree.
-    if (this.isMedical && awardPriority == 6) {
-      return BadgeImages.flightMedicBadge;
-    }
-
-    return awardPriority;
+    this.imageNum = registryDetails.badgeImage;
   }
 
   updateBadgeCombat(newAwardData, AwardRegistry) {
     const registryDetails = AwardRegistry.getAwardDetails(
       newAwardData.awardName,
     );
-    const newAwardPriority = registryDetails.awardPriority;
 
-    if (
-      newAwardPriority > this.awardPriority &&
-      newAwardPriority <= this.maxAllowed
-    ) {
-      if (
-        newAwardData.awardName == AwardNameFragment.FLIGHT_MEDIC_BADGE &&
-        !this.isMedical
-      ) {
-        return;
-      }
-
-      if (
-        newAwardData.awardName.includes(AwardNameFragment.AVIATOR) &&
-        !this.isAviation
-      ) {
-        return;
-      }
-
+    if (registryDetails.awardPriority > this.awardPriority) {
       this.awardTitle = newAwardData.awardName;
-      this.awardPriority = newAwardPriority;
-      this.imageNum = this.getImageNum(newAwardPriority);
+      this.awardPriority = registryDetails.awardPriority;
+      this.imageNum = registryDetails.badgeImage;
     }
   }
 }

--- a/client/app/uniformbuilder/modules/canvas.jsx
+++ b/client/app/uniformbuilder/modules/canvas.jsx
@@ -8,6 +8,7 @@ import {
   MedalTiered,
   RibbonDonationLogic,
 } from "./AwardClasses";
+import { combatBadgeImagePath } from "./constants";
 
 function Canvas(props) {
   const canvasRef = useRef(null);
@@ -59,10 +60,7 @@ function Canvas(props) {
 
     if (data[4] != null) {
       imagePromises.push(
-        loadImage(
-          `skunkworks/uniformBadges/combatBadges/${data[4].imageNum}.png`,
-          "uniformCombatBadge",
-        ),
+        loadImage(combatBadgeImagePath(data[4].imageNum), "uniformCombatBadge"),
       );
     }
 

--- a/client/app/uniformbuilder/modules/constants/awardCatalog.js
+++ b/client/app/uniformbuilder/modules/constants/awardCatalog.js
@@ -3,6 +3,8 @@
 // placement, and Node's ESM resolver does not guess extensions.
 import { AwardType } from "./awardTypes.js";
 import { AwardAttachmentType } from "./awardAttachmentTypes.js";
+import { BadgeFamily } from "./badgeFamilies.js";
+import { BadgeImages } from "./badgeImages.js";
 
 // The full award catalog: name + per-award metadata. AwardRegistry loops this
 // in order to populate its Map, so KEEP THE ORDER STABLE — Map iteration order
@@ -429,61 +431,85 @@ export const AWARD_CATALOG = [
     name: "Flight Medic Badge",
     awardPriority: 6,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.flightMedicBadge,
+    badgeFamily: BadgeFamily.FLIGHT_MEDIC,
   }, // (3/1/b/1-7) (4/1/b/1-7)
   {
     name: "Master Army Aviator Badge",
     awardPriority: 11,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.masterAviator,
+    badgeFamily: BadgeFamily.AVIATOR,
   }, // (A/1-7) (A/ACD)
   {
     name: "Senior Army Aviator Badge",
     awardPriority: 10,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.seniorAviator,
+    badgeFamily: BadgeFamily.AVIATOR,
   },
   {
     name: "Army Aviator Badge",
     awardPriority: 9,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.aviator,
+    badgeFamily: BadgeFamily.AVIATOR,
   },
   {
     name: "Aircraft Master Crewman Badge",
     awardPriority: 8,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.masterAircrew,
+    badgeFamily: BadgeFamily.AIRCREW,
   }, // (A/1-7) (A/ACD)
   {
     name: "Aircraft Senior Crewman Badge",
     awardPriority: 7,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.seniorAircrew,
+    badgeFamily: BadgeFamily.AIRCREW,
   },
   {
     name: "Aircraft Crewman Badge",
     awardPriority: 6,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.aircrew,
+    badgeFamily: BadgeFamily.AIRCREW,
   },
   {
     name: "Combat Infantry Badge 4th Award",
     awardPriority: 5,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.combatInfantryFourth,
+    badgeFamily: BadgeFamily.INFANTRY,
   },
   {
     name: "Combat Infantry Badge 3rd Award",
     awardPriority: 4,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.combatInfantryThird,
+    badgeFamily: BadgeFamily.INFANTRY,
   },
   {
     name: "Combat Infantry Badge 2nd Award",
     awardPriority: 3,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.combatInfantrySecond,
+    badgeFamily: BadgeFamily.INFANTRY,
   },
   {
     name: "Combat Infantry Badge",
     awardPriority: 2,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.combatInfantry,
+    badgeFamily: BadgeFamily.INFANTRY,
   },
   {
     name: "Expert Infantry Badge",
     awardPriority: 1,
     awardType: AwardType.BadgeCombat,
+    badgeImage: BadgeImages.expertInfantry,
+    badgeFamily: BadgeFamily.INFANTRY,
   }, // et. al.
 
   //____ WEAPON QUALS ____

--- a/client/app/uniformbuilder/modules/constants/awardCatalog.test.js
+++ b/client/app/uniformbuilder/modules/constants/awardCatalog.test.js
@@ -1,0 +1,69 @@
+/**
+ * Seam: AWARD_CATALOG as data.
+ *
+ * Combat badges are only displayed to members whose MOS wears that badge's
+ * family, so a combat-badge entry without a badgeFamily is worn by nobody. That
+ * failure is silent — the badge simply never appears on a uniform — and no
+ * behavioural test catches it, because a test only covers the badges it names.
+ * This reads the real catalog rather than a fixture, for the reason
+ * generateAwardSprites.test.js records: a fixture cannot catch the award data
+ * moving or changing shape.
+ *
+ * Run with `npm run test:client`.
+ */
+
+import assert from "node:assert";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHarness } from "../../../../test-harness.mjs";
+import { AWARD_CATALOG } from "./awardCatalog.js";
+import { AwardType } from "./awardTypes.js";
+import { BadgeFamily } from "./badgeFamilies.js";
+import { BadgeImages, combatBadgeImagePath } from "./badgeImages.js";
+
+// combatBadgeImagePath returns the path the browser requests, relative to the
+// public directory the app is served from.
+const PUBLIC_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../public",
+);
+
+const { test, report } = createHarness();
+
+const combatBadges = AWARD_CATALOG.filter(
+  (award) => award.awardType === AwardType.BadgeCombat,
+);
+
+await test("the catalog still contains combat badges to check", () => {
+  // Guards the filter above: if awardType or the catalog shape moves, every
+  // other assertion here would pass vacuously over an empty list.
+  assert.ok(combatBadges.length > 0);
+});
+
+const knownFamilies = Object.values(BadgeFamily);
+const knownImages = Object.values(BadgeImages);
+
+for (const badge of combatBadges) {
+  await test(`${badge.name} belongs to a known badge family`, () => {
+    assert.ok(
+      knownFamilies.includes(badge.badgeFamily),
+      `badgeFamily was ${JSON.stringify(badge.badgeFamily)}; a combat badge ` +
+        `without a recognised family is displayed to nobody`,
+    );
+  });
+
+  await test(`${badge.name} names an image that exists`, () => {
+    assert.ok(
+      knownImages.includes(badge.badgeImage),
+      `badgeImage was ${JSON.stringify(badge.badgeImage)}, which is not one ` +
+        `of the images BadgeImages names`,
+    );
+    // Reached through the same helper canvas.jsx renders from, so a badge whose
+    // artwork was never committed fails here rather than 404ing on a uniform.
+    const path = join(PUBLIC_DIR, combatBadgeImagePath(badge.badgeImage));
+    assert.ok(existsSync(path), `no image file at ${path}`);
+  });
+}
+
+report();

--- a/client/app/uniformbuilder/modules/constants/awardNames.js
+++ b/client/app/uniformbuilder/modules/constants/awardNames.js
@@ -3,8 +3,6 @@
 export const AwardNameFragment = Object.freeze({
   // Matched bare via .includes(); the " " + form is the suffix stripped via .replace().
   VALOR_DEVICE: "with Valor Device",
-  FLIGHT_MEDIC_BADGE: "Flight Medic Badge",
-  AVIATOR: "Aviator",
 });
 
 // Does this award name carry the " with Valor Device" suffix?

--- a/client/app/uniformbuilder/modules/constants/badgeFamilies.js
+++ b/client/app/uniformbuilder/modules/constants/badgeFamilies.js
@@ -1,0 +1,38 @@
+// Extensions are explicit here for the same reason as awardCatalog.js: this
+// module is reachable from plain Node, whose ESM resolver does not guess them.
+import { MosGroup } from "./mos.js";
+
+// Combat badges come in four families. Which family a badge belongs to is a
+// property of the badge, not of its rank within a member's ladder: two badges
+// can share an awardPriority and still belong to different families. The Flight
+// Medic Badge and the Aircraft Crewman Badge both sit at priority 6, and telling
+// them apart by priority is impossible — that is what the family is for.
+export const BadgeFamily = Object.freeze({
+  INFANTRY: "infantry",
+  FLIGHT_MEDIC: "flightMedic",
+  AIRCREW: "aircrew",
+  AVIATOR: "aviator",
+});
+
+// The badge families a member may display, by MOS. A member can hold a badge
+// they may not display: aircrew badges are awarded to troopers outside the
+// aviation MOSs, but only aviation MOSs wear them.
+export function displayableBadgeFamilies(userMos) {
+  const families = [BadgeFamily.INFANTRY];
+
+  if (MosGroup.MEDICAL.includes(userMos)) {
+    families.push(BadgeFamily.FLIGHT_MEDIC);
+  }
+
+  if (MosGroup.AVIATION.includes(userMos)) {
+    families.push(BadgeFamily.AIRCREW);
+
+    // Crewmen stop at the aircrew badges; the aviator badges are the
+    // pilots'.
+    if (!MosGroup.ROTARY_CREW.includes(userMos)) {
+      families.push(BadgeFamily.AVIATOR);
+    }
+  }
+
+  return families;
+}

--- a/client/app/uniformbuilder/modules/constants/badgeImages.js
+++ b/client/app/uniformbuilder/modules/constants/badgeImages.js
@@ -1,9 +1,16 @@
-// Enum of common names for combat badges within:
-// client/public/skunkworks/uniformBadges/combatBadges/<n>.png
-// this is used to select the proper image for layering within canvas.jsx
-// For example, the Aviator Badge is known as 7.png within the files themselves.
-// Values 1 - 5 are EIB thru CIB 4. These are universal and do not require special enumeration.
+// Combat badge images, by the filename they are stored under in
+// client/public/skunkworks/uniformBadges/combatBadges/<n>.png.
+//
+// Each combat badge in awardCatalog.js names its image here. Do not derive the
+// image from a badge's awardPriority: priority ranks a badge within a member's
+// ladder and is deliberately not unique across badges — the Flight Medic Badge
+// and the Aircraft Crewman Badge share priority 6 — so it cannot identify one.
 export const BadgeImages = Object.freeze({
+  expertInfantry: 1,
+  combatInfantry: 2,
+  combatInfantrySecond: 3,
+  combatInfantryThird: 4,
+  combatInfantryFourth: 5,
   flightMedicBadge: 6,
   aviator: 7,
   seniorAviator: 8,
@@ -12,3 +19,9 @@ export const BadgeImages = Object.freeze({
   seniorAircrew: 11,
   masterAircrew: 12,
 });
+
+// The one place the badge image path is built. canvas.jsx renders from this and
+// the catalog test checks files through it, so the two cannot drift apart.
+export function combatBadgeImagePath(imageNum) {
+  return `skunkworks/uniformBadges/combatBadges/${imageNum}.png`;
+}

--- a/client/app/uniformbuilder/modules/constants/index.js
+++ b/client/app/uniformbuilder/modules/constants/index.js
@@ -7,4 +7,5 @@ export {
   stripValorDevice,
 } from "./awardNames";
 export { AWARD_CATALOG } from "./awardCatalog";
-export { BadgeImages } from "./badgeImages";
+export { BadgeFamily, displayableBadgeFamilies } from "./badgeFamilies";
+export { BadgeImages, combatBadgeImagePath } from "./badgeImages";

--- a/client/app/uniformbuilder/modules/constants/mos.js
+++ b/client/app/uniformbuilder/modules/constants/mos.js
@@ -78,9 +78,10 @@ export const Mos = Object.freeze({
   DEVCOM_SUPPORT_COORDINATOR: "51S",
 });
 
-// Semantic groupings used by BadgeCombat badge logic in AwardClasses.jsx.
-// Membership matches the post-#129 aviation behavior (155F counts as aviation,
-// only 15T is aircrew). Do not change membership without checking that logic.
+// Semantic groupings used by the badge-eligibility logic in
+// constants/badgeFamilies.js. Membership matches the post-#129 aviation
+// behavior (155F counts as aviation, only 15T crews rather than pilots). Do not
+// change membership without checking that logic.
 export const MosGroup = Object.freeze({
   AVIATION: [
     Mos.ROTARY_WING_AVIATOR_WARRANT_OFFICER,
@@ -90,5 +91,6 @@ export const MosGroup = Object.freeze({
     Mos.JET_AIRCRAFT_PILOT,
   ],
   MEDICAL: [Mos.COMBAT_MEDIC, Mos.MEDICAL_OFFICER],
-  AIRCREW: [Mos.ENLISTED_ROTARY_CREWMAN],
+  // Aviation MOSs that crew aircraft rather than pilot them.
+  ROTARY_CREW: [Mos.ENLISTED_ROTARY_CREWMAN],
 });

--- a/client/app/uniformbuilder/modules/getCanvasObject.jsx
+++ b/client/app/uniformbuilder/modules/getCanvasObject.jsx
@@ -18,10 +18,13 @@ import {
   AwardAttachmentType,
   hasValorDevice,
   stripValorDevice,
+  displayableBadgeFamilies,
 } from "./constants";
 
 export default async function GetCanvasObject(userName) {
   const data = await GetIndividual(userName);
+
+  const displayableFamilies = displayableBadgeFamilies(data.mos);
 
   let awardCounts = [];
   let totalRibbonCount = 0;
@@ -43,7 +46,18 @@ export default async function GetCanvasObject(userName) {
     let useCombatBadgeLogic = false;
     let combatBadgeKey;
 
-    const awardType = AwardRegistryInstance.getAwardDetails(key).awardType;
+    const registryDetails = AwardRegistryInstance.getAwardDetails(key);
+    const awardType = registryDetails.awardType;
+
+    //A member can hold a combat badge their MOS does not wear — an aircrew
+    //badge earned by a medic, say. It stays on their record; it just never
+    //reaches the uniform.
+    if (
+      awardType == AwardType.BadgeCombat &&
+      !displayableFamilies.includes(registryDetails.badgeFamily)
+    ) {
+      continue;
+    }
 
     if (
       awardType == AwardType.BadgeCombat ||
@@ -156,7 +170,6 @@ export default async function GetCanvasObject(userName) {
           case AwardType.BadgeCombat:
             const newBadgeCombat = new BadgeCombat(
               data.awards[i],
-              data.mos,
               AwardRegistryInstance,
             );
             awardMap.set(AwardType.BadgeCombat, newBadgeCombat);

--- a/client/app/uniformbuilder/modules/getCanvasObject.test.js
+++ b/client/app/uniformbuilder/modules/getCanvasObject.test.js
@@ -1,0 +1,158 @@
+/**
+ * Seam: GetCanvasObject(userName) — the module's default export, and the only
+ * function the uniform builder page calls.
+ *
+ * canvas.jsx reads exactly two things about the combat badge: whether data[4]
+ * is null (nothing is drawn), and data[4].imageNum (which badge image is
+ * drawn). Those are the only things asserted here. awardTitle and the rest of
+ * the badge object are internal and are deliberately left alone, so this suite
+ * survives a rewrite of how the badge is chosen.
+ *
+ * The only stub is globalThis.fetch, the outermost network adapter. No
+ * internal collaborator is mocked.
+ *
+ * Expected image numbers are literals, transcribed from the badge artwork in
+ * public/skunkworks/uniformBadges/combatBadges — 6.png is wings with a
+ * caduceus, 10/11/12.png are aircrew wings plain / with a star / with a star in
+ * a wreath, and so on. They are deliberately NOT read back from the catalog:
+ * sourcing them from the data under test would move both sides of the
+ * assertion together and no row could ever fail.
+ *
+ * Run with `npm run test:client` — not a bare `node`; the script carries the
+ * loader hook that lets Node import the client's .jsx modules.
+ */
+
+// getIndividual.js reads these at module scope, so they have to be set before
+// the import below rather than per-test.
+process.env.NEXT_PUBLIC_INDIVIDUAL_API_URL ??=
+  "http://uniform-builder.test/individual";
+process.env.NEXT_PUBLIC_CLIENT_TOKEN ??= "test-client-token";
+
+import assert from "node:assert";
+import { createHarness } from "../../../test-harness.mjs";
+
+// getIndividual.js reads the two variables above at module scope, so this one
+// import has to happen after they are set — hence dynamic rather than static.
+const { default: GetCanvasObject } = await import("./getCanvasObject.jsx");
+
+const { test, report } = createHarness();
+
+/**
+ * Mirrors the roster API response as getCanvasObject.jsx and GetUserInfo.jsx
+ * consume it. `awardName` is the field that links a fetched award to its
+ * catalog entry, and the API returns the catalog's own award names.
+ */
+const rosterResponse = (mos, awardNames) => ({
+  user: { username: "Weather.J" },
+  rank: { rankShort: "SPC", rankId: "19" }, // E4, Specialist
+  mos,
+  awards: awardNames.map((awardName) => ({ awardName, awardDetails: "" })),
+});
+
+/** The combat badge the builder hands the renderer, or null for none. */
+const combatBadgeFor = async (mos, awardNames) => {
+  const payload = rosterResponse(mos, awardNames);
+  globalThis.fetch = async () => ({ status: 200, json: async () => payload });
+  return (await GetCanvasObject(payload.user.username))[4];
+};
+
+const assertDraws = (badge, expectedImageNum) => {
+  assert.notStrictEqual(badge, null, "expected a combat badge, got none");
+  assert.strictEqual(badge.imageNum, expectedImageNum);
+};
+
+const assertDrawsNothing = (badge) => {
+  // Deliberately strict: a badge object carrying an undefined imageNum is not
+  // "nothing drawn", it is a request for combatBadges/undefined.png.
+  assert.strictEqual(badge, null);
+};
+
+// ── Identity: every badge is drawn as itself ─────────────────────────────────
+// One row per badge, held alone by a MOS entitled to wear it. These guard the
+// badge-to-image and MOS-to-family data against mis-tagging; they do not
+// reproduce any reported defect.
+
+const EVERY_BADGE_DRAWN_BY_AN_ELIGIBLE_WEARER = [
+  ["Expert Infantry Badge", "11B", 1],
+  ["Combat Infantry Badge", "11B", 2],
+  ["Combat Infantry Badge 2nd Award", "11B", 3],
+  ["Combat Infantry Badge 3rd Award", "11B", 4],
+  ["Combat Infantry Badge 4th Award", "11B", 5],
+  ["Flight Medic Badge", "68W", 6],
+  ["Army Aviator Badge", "153A", 7],
+  ["Senior Army Aviator Badge", "153A", 8],
+  ["Master Army Aviator Badge", "153A", 9],
+  ["Aircraft Crewman Badge", "15T", 10],
+  ["Aircraft Senior Crewman Badge", "15T", 11],
+  ["Aircraft Master Crewman Badge", "15T", 12],
+];
+
+for (const [
+  awardName,
+  mos,
+  imageNum,
+] of EVERY_BADGE_DRAWN_BY_AN_ELIGIBLE_WEARER) {
+  await test(`${mos} draws ${awardName} as itself`, async () => {
+    assertDraws(await combatBadgeFor(mos, [awardName]), imageNum);
+  });
+}
+
+// ── Refusal: a badge whose family this MOS does not wear ─────────────────────
+// These are the reported defect. A combat medic in an aviation company can earn
+// the Aircraft Crewman Badge, but aircrew badges are worn by aviation MOSs
+// only. Before the fix all three drew a badge the member had never been
+// awarded.
+
+await test("68W holding only an aircrew badge displays no combat badge", async () => {
+  assertDrawsNothing(await combatBadgeFor("68W", ["Aircraft Crewman Badge"]));
+});
+
+await test("11B holding only an aircrew badge displays no combat badge", async () => {
+  assertDrawsNothing(await combatBadgeFor("11B", ["Aircraft Crewman Badge"]));
+});
+
+await test("15T holding only an aviator badge displays no combat badge", async () => {
+  // 15T crew aircraft rather than fly them, so the aviator badges are not
+  // theirs to wear even when earned.
+  assertDrawsNothing(await combatBadgeFor("15T", ["Army Aviator Badge"]));
+});
+
+await test("153A holding only a flight medic badge displays no combat badge", async () => {
+  // The flight medic badge belongs to the medical MOSs. Before the fix an
+  // aviation MOS holding one was drawn the aircrew badge, which is neither the
+  // badge held nor a badge they had earned.
+  assertDrawsNothing(await combatBadgeFor("153A", ["Flight Medic Badge"]));
+});
+
+// ── Selection: the highest badge the member may wear, whatever the order ─────
+// The API's ordering of a member's awards is not guaranteed, and the badge is
+// built by a different code path depending on which award arrives first. Each
+// case is therefore run in both orderings.
+
+await test("68W wears his highest CIB, not the aircrew badge, in any award order", async () => {
+  // SPC Weather.J's record: five combat badges, one of them an aircrew badge
+  // he earned but may not wear.
+  const held = [
+    "Expert Infantry Badge",
+    "Combat Infantry Badge",
+    "Aircraft Crewman Badge",
+    "Combat Infantry Badge 2nd Award",
+    "Combat Infantry Badge 3rd Award",
+  ];
+  assertDraws(await combatBadgeFor("68W", held), 4);
+  assertDraws(await combatBadgeFor("68W", [...held].reverse()), 4);
+});
+
+await test("11B wears his highest CIB over an aircrew badge, in any award order", async () => {
+  const held = ["Aircraft Crewman Badge", "Combat Infantry Badge 3rd Award"];
+  assertDraws(await combatBadgeFor("11B", held), 4);
+  assertDraws(await combatBadgeFor("11B", [...held].reverse()), 4);
+});
+
+await test("68W wears the Flight Medic Badge over a CIB, in any award order", async () => {
+  const held = ["Combat Infantry Badge", "Flight Medic Badge"];
+  assertDraws(await combatBadgeFor("68W", held), 6);
+  assertDraws(await combatBadgeFor("68W", [...held].reverse()), 6);
+});
+
+report();

--- a/client/test-harness.mjs
+++ b/client/test-harness.mjs
@@ -1,0 +1,34 @@
+// The repo runs its tests as plain node scripts rather than under a framework
+// (see generateAwardSprites.test.js), so this is the shared scaffolding: run
+// each case, keep going after a failure, and report them all at the end.
+export function createHarness() {
+  const failures = [];
+  let ran = 0;
+
+  const test = async (name, run) => {
+    ran++;
+    try {
+      await run();
+      console.log(`  ok    ${name}`);
+    } catch (error) {
+      failures.push({ name, error });
+      console.log(`  FAIL  ${name}`);
+    }
+  };
+
+  // Prints the failures and exits non-zero if there were any, so the npm script
+  // fails the build.
+  const report = () => {
+    console.log("");
+    if (failures.length > 0) {
+      for (const { name, error } of failures) {
+        console.error(`FAIL  ${name}\n${error.message}\n`);
+      }
+      console.error(`${failures.length} failing`);
+      process.exit(1);
+    }
+    console.log(`all ${ran} passing`);
+  };
+
+  return { test, report };
+}

--- a/client/test-loader.mjs
+++ b/client/test-loader.mjs
@@ -1,0 +1,40 @@
+// Lets plain Node run the client's tests. The app is built for Next.js, which
+// resolves `.jsx` files and extensionless/directory imports for us; Node does
+// neither. These hooks add both so a test can import the real modules rather
+// than a copy of them.
+//
+// The `.jsx` files under app/uniformbuilder/modules contain no JSX syntax, so
+// they need no transform — only permission to be treated as ES modules.
+import { registerHooks } from "node:module";
+import { readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const CANDIDATE_SUFFIXES = ["", ".jsx", ".js", "/index.js"];
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith(".") || specifier.startsWith("/")) {
+      for (const suffix of CANDIDATE_SUFFIXES) {
+        try {
+          const resolved = nextResolve(specifier + suffix, context);
+          if (statSync(fileURLToPath(resolved.url)).isFile()) return resolved;
+        } catch {
+          // Try the next suffix. If none resolve, the unsuffixed call below
+          // reports the failure with Node's own message.
+        }
+      }
+    }
+    return nextResolve(specifier, context);
+  },
+
+  load(url, context, nextLoad) {
+    if (url.endsWith(".jsx")) {
+      return {
+        format: "module",
+        source: readFileSync(fileURLToPath(url), "utf8"),
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
     "format:check": "prettier --check \"{**/*,*}.{js,jsx,json,html,css}\"",
     "format": "prettier --write \"{**/*,*}.{js,jsx,json,html,css}\"",
     "sprites:generate": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON generateAwardSprites.js",
-    "test": "npm run test:sprites && npm run test:server",
+    "test": "npm run test:sprites && npm run test:client && npm run test:server",
     "test:sprites": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON generateAwardSprites.test.js",
+    "test:client": "npm run test:client:catalog && npm run test:client:canvas",
+    "test:client:catalog": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --import ./client/test-loader.mjs client/app/uniformbuilder/modules/constants/awardCatalog.test.js",
+    "test:client:canvas": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --import ./client/test-loader.mjs client/app/uniformbuilder/modules/getCanvasObject.test.js",
     "test:server": "npm --prefix server test"
   },
   "devDependencies": {
@@ -14,6 +17,6 @@
     "sharp": "^0.35.0"
   },
   "engines": {
-    "node": ">=22.7"
+    "node": ">=22.15"
   }
 }


### PR DESCRIPTION
## The bug

[SPC Weather.J](https://7cav.us/rosters/profile/5496/) (68W, Trooper 4/1/A/1-7) was drawn the **Flight Medic Badge**, which he has never been awarded. 

`Flight Medic Badge` and `Aircraft Crewman Badge` both carry `awardPriority: 6` in the catalog, and the badge *image* was chosen from that number plus the member's MOS group rather than from the badge actually held. Any medical MOS holding the aircrew badge was therefore drawn the flight medic's.

His record holds EIB, CIB, **Aircraft Crewman Badge**, CIB 2nd, CIB 3rd — and no Flight Medic Badge.

## The ruling

Asked whether a non-aviation MOS can ever wear an aircrew badge they've earned, S1's answer was *"in general, it shouldn't be the case."* So Weather.J wears his **Combat Infantry Badge 3rd Award**.

| MOS group | may display |
|---|---|
| aviation, non-15T (`153A`, `155A`, `15A`, `155F`) | infantry, aircrew, aviator |
| `15T` | infantry, aircrew |
| medical (`68W`, `67A`) | infantry, flight medic |
| everything else | infantry |

This reproduces every outcome the old code got *right* — the 15T aviator cap, the 11B/19D block, the legitimate flight medic — and changes only the ones it got wrong.

## The change

Combat badges declare a `badgeFamily` and a `badgeImage` in the catalog. `getCanvasObject` drops any badge whose family the member's MOS doesn't wear **before** the badge object is built, and `BadgeCombat` reads its image from the catalog entry instead of deriving it.

That replaces three partial mechanisms — the numeric `maxAllowed` ceiling, the award-name substring guards in `updateBadgeCombat`, and the MOS-keyed `getImageNum` map. **None of them covered the constructor**, so whichever badge the API happened to list first was accepted unchecked. `AwardClasses.jsx` loses 100 lines.

`awardPriority` goes back to meaning only "rank within the ladder", which is what its name always claimed.

## Behaviour changes beyond the fix

Both restore documented intent rather than preserving current behaviour:

- A **15T holding only an aviator badge** displayed the aviator badge; now displays nothing. `AwardClasses.jsx` said 15T should "stop at aircrew badges", but the constructor bypassed the ceiling.
- An **aviation MOS holding a flight medic badge** displayed the *aircrew* badge — neither the badge held nor one earned; now displays nothing.

## Tests

First test suite on the client (`npm run test:client`, wired into `npm test`). The seam is `GetCanvasObject`, asserting only the two things `canvas.jsx` reads — whether `data[4]` is null, and `data[4].imageNum`. Only `globalThis.fetch` is stubbed.

- **identity** (12) — each badge held alone by an eligible MOS draws its own image. Expected image numbers are literals read off the artwork, deliberately *not* read back from the catalog, so a mis-tag can't move both sides of the assertion together.
- **refusal** (4) — ineligible family draws nothing. Strict `=== null`, since a badge object with an undefined `imageNum` is a request for `combatBadges/undefined.png`, not "nothing drawn".
- **selection & ordering** (3) — multi-award, run in **both** award orderings, because the badge is built by a different code path depending which award arrives first.
- **catalog** (25) — every combat badge names a known family and artwork that exists on disk, reached through the same path helper the renderer uses. Reads the real catalog, per the precedent in `generateAwardSprites.test.js`.

Mutation-tested: dropping a family from a MOS, adding one, and breaking a catalog entry each redden a distinct, minimal set of rows.

## Note for reviewers

`engines` moves to `>=22.15` — the test loader uses `module.registerHooks`, which landed in 22.15. CI's `lts/*` already clears it.

> *This was generated by AI*
