### PR TITLE
refactor: make medal worksheets definition-driven

### DIFF
--- a/client/app/medalrecommendation/MedalRecommendationClient.jsx
+++ b/client/app/medalrecommendation/MedalRecommendationClient.jsx
@@ -17,6 +17,12 @@ import {
   mergeHighlightRanges,
 } from "./lib/narrative-validation";
 import { OPERATION_MEDALS } from "./lib/medal-definitions";
+import {
+  applyAwardChange,
+  getCitationChoiceText,
+  resolveMedalWorksheet,
+} from "./lib/worksheet-profiles";
+import { validateWorksheet } from "./lib/worksheet-validation";
 
 function formatOperationDate(value) {
   const [year, month, day] = value.split("-").map(Number);
@@ -39,32 +45,6 @@ function getCitationName(fullName) {
   }
 
   return `${nameParts[0]} ${nameParts[nameParts.length - 1]}`;
-}
-
-function isOperationDateValid(value) {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return false;
-  }
-
-  const [year, month, day] = value.split("-").map(Number);
-  const date = new Date(Date.UTC(year, month - 1, day));
-
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month - 1 ||
-    date.getUTCDate() !== day
-  ) {
-    return false;
-  }
-
-  const now = new Date();
-  const localToday = [
-    String(now.getFullYear()).padStart(4, "0"),
-    String(now.getMonth() + 1).padStart(2, "0"),
-    String(now.getDate()).padStart(2, "0"),
-  ].join("-");
-
-  return value <= localToday;
 }
 
 function renderNarrativeWithHighlights(text, highlightRanges) {
@@ -148,6 +128,8 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
   const selectedMedal =
     OPERATION_MEDALS.find((medal) => medal.id === selectedMedalId) ?? null;
 
+  const selectedWorksheet = resolveMedalWorksheet(selectedMedal);
+
   const rankEntries = useMemo(
     () => getRankEntries(rosterMembers),
     [rosterMembers],
@@ -176,53 +158,72 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
     selectedRecipient && recipientRank && recipientRosterName,
   );
 
+  const worksheetValidation = validateWorksheet(selectedWorksheet, {
+    actionCharacter,
+    scope,
+    combatElement,
+    operationTitle,
+    location,
+    operationDate,
+    narrative,
+  });
+
   const actionCharacterIsValid =
-    !selectedMedal?.fields.actionCharacter || Boolean(actionCharacter);
+    worksheetValidation.fields.actionCharacter ?? true;
 
-  const scopeIsValid = !selectedMedal?.fields.scope || Boolean(scope);
+  const scopeIsValid = worksheetValidation.fields.scope ?? true;
 
-  const combatElementIsValid = Boolean(combatElement.trim());
+  const combatElementIsValid =
+    worksheetValidation.fields.combatElement ?? false;
 
-  const operationTitleIsValid = Boolean(operationTitle.trim());
+  const operationTitleIsValid =
+    worksheetValidation.fields.operationTitle ?? false;
 
-  const locationIsValid = Boolean(location.trim());
+  const locationIsValid = worksheetValidation.fields.location ?? false;
 
-  const operationDateIsValid = isOperationDateValid(operationDate);
+  const operationDateIsValid =
+    worksheetValidation.fields.operationDate ?? false;
 
-  const narrativeIsValid = Boolean(narrative.trim());
+  const narrativeIsValid = worksheetValidation.fields.narrative ?? false;
 
-  const isComplete =
-    recipientIsValid &&
-    actionCharacterIsValid &&
-    scopeIsValid &&
-    combatElementIsValid &&
-    operationTitleIsValid &&
-    locationIsValid &&
-    operationDateIsValid &&
-    narrativeIsValid;
+  const isComplete = recipientIsValid && worksheetValidation.isComplete;
 
   const recipientIsInvalid = hasAttemptedGenerate && !recipientIsValid;
 
   const actionCharacterIsInvalid =
     hasAttemptedGenerate &&
-    Boolean(selectedMedal?.fields.actionCharacter) &&
+    Boolean(selectedWorksheet?.fields.actionCharacter) &&
     !actionCharacterIsValid;
 
   const scopeIsInvalid =
     hasAttemptedGenerate &&
-    Boolean(selectedMedal?.fields.scope) &&
+    Boolean(selectedWorksheet?.fields.scope) &&
     !scopeIsValid;
 
-  const combatElementIsInvalid = hasAttemptedGenerate && !combatElementIsValid;
+  const combatElementIsInvalid =
+    hasAttemptedGenerate &&
+    Boolean(selectedWorksheet?.fields.combatElement) &&
+    !combatElementIsValid;
 
   const operationTitleIsInvalid =
-    hasAttemptedGenerate && !operationTitleIsValid;
+    hasAttemptedGenerate &&
+    Boolean(selectedWorksheet?.fields.operationTitle) &&
+    !operationTitleIsValid;
 
-  const locationIsInvalid = hasAttemptedGenerate && !locationIsValid;
+  const locationIsInvalid =
+    hasAttemptedGenerate &&
+    Boolean(selectedWorksheet?.fields.location) &&
+    !locationIsValid;
 
-  const operationDateIsInvalid = hasAttemptedGenerate && !operationDateIsValid;
+  const operationDateIsInvalid =
+    hasAttemptedGenerate &&
+    Boolean(selectedWorksheet?.fields.operationDate) &&
+    !operationDateIsValid;
 
-  const narrativeIsInvalid = hasAttemptedGenerate && !narrativeIsValid;
+  const narrativeIsInvalid =
+    hasAttemptedGenerate &&
+    Boolean(selectedWorksheet?.fields.narrative) &&
+    !narrativeIsValid;
 
   const hasNarrativeWarnings = Boolean(
     recommendation?.narrativeWarnings?.length,
@@ -262,6 +263,13 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
       .trim()
       .replace(/^operation\s+/i, "");
 
+    const citationActionCharacter = selectedWorksheet?.fields.actionCharacter
+      ? getCitationChoiceText(
+          selectedWorksheet.fields.actionCharacter,
+          actionCharacter,
+        )
+      : "";
+
     const narrativeAnalysis = analyzeNarrative(narrative, {
       recipientRank,
       recipientCitationName,
@@ -275,7 +283,7 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
     }
 
     const citationContext = {
-      actionCharacter,
+      actionCharacter: citationActionCharacter,
       scope,
       combatElement: combatElement.trim(),
       operationTitle: normalizedOperationTitle,
@@ -288,6 +296,7 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
     const openingSentence = selectedMedal.buildOpening(citationContext);
 
     const closingSentence = selectedMedal.buildClosing(citationContext);
+
     setRecommendation({
       recipient: `${recipientRank} ${recipientCitationName}`,
       openingSentence,
@@ -318,16 +327,30 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
             const nextMedal =
               OPERATION_MEDALS.find((medal) => medal.id === value) ?? null;
 
-            if (
-              selectedMedal?.fields.combatElementLabel !==
-              nextMedal?.fields.combatElementLabel
-            ) {
-              setCombatElement("");
-            }
+            const nextWorksheet = resolveMedalWorksheet(nextMedal);
+
+            const nextValues = applyAwardChange(
+              selectedWorksheet,
+              nextWorksheet,
+              {
+                actionCharacter,
+                scope,
+                combatElement,
+                operationTitle,
+                location,
+                operationDate,
+                narrative,
+              },
+            );
 
             setSelectedMedalId(value);
-            setActionCharacter("");
-            setScope("");
+            setActionCharacter(nextValues.actionCharacter ?? "");
+            setScope(nextValues.scope ?? "");
+            setCombatElement(nextValues.combatElement ?? "");
+            setOperationTitle(nextValues.operationTitle ?? "");
+            setLocation(nextValues.location ?? "");
+            setOperationDate(nextValues.operationDate ?? "");
+            setNarrative(nextValues.narrative ?? "");
             setHasAttemptedGenerate(false);
             setRecommendation(null);
           }}
@@ -365,6 +388,7 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
             {selectedMedal.eligibilityNotes.length > 0 && (
               <div className="space-y-2">
                 <h3 className="font-semibold text-primary">Eligibility</h3>
+
                 <ul className="list-disc space-y-1 pl-5">
                   {selectedMedal.eligibilityNotes.map((note) => (
                     <li key={note}>{note}</li>
@@ -461,7 +485,7 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
               )}
             </div>
 
-            {selectedMedal.fields.actionCharacter && (
+            {selectedWorksheet?.fields.actionCharacter && (
               <div className="flex flex-col gap-2">
                 <label
                   htmlFor="action-character"
@@ -495,11 +519,13 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                   </SelectTrigger>
 
                   <SelectContent>
-                    {selectedMedal.actionCharacterOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
+                    {selectedWorksheet.fields.actionCharacter.options.map(
+                      (option) => (
+                        <SelectItem key={option.id} value={option.id}>
+                          {option.label}
+                        </SelectItem>
+                      ),
+                    )}
                   </SelectContent>
                 </Select>
 
@@ -513,7 +539,8 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                 )}
               </div>
             )}
-            {selectedMedal.fields.scope && (
+
+            {selectedWorksheet?.fields.scope && (
               <div className="flex flex-col gap-2">
                 <label htmlFor="scope" className="pb-1 text-sm font-medium">
                   Scope
@@ -542,13 +569,14 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
                   </SelectTrigger>
 
                   <SelectContent>
-                    {selectedMedal.scopeOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
+                    {selectedWorksheet.fields.scope.options.map((option) => (
+                      <SelectItem key={option.id} value={option.id}>
                         {option.label}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
+
                 {scopeIsInvalid && (
                   <p
                     id="scope-required"
@@ -560,209 +588,227 @@ export default function MedalRecommendationClient({ recipientRoster = [] }) {
               </div>
             )}
 
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="combat-element"
-                className="pb-1 text-sm font-medium"
-              >
-                {selectedMedal.fields.combatElementLabel}
-              </label>
-
-              <Input
-                id="combat-element"
-                type="text"
-                value={combatElement}
-                placeholder={selectedMedal.fields.combatElementPlaceholder}
-                aria-invalid={combatElementIsInvalid ? "true" : undefined}
-                aria-describedby={
-                  combatElementIsInvalid ? "combat-element-required" : undefined
-                }
-                className={
-                  combatElementIsInvalid
-                    ? "border-destructive focus-visible:ring-destructive"
-                    : undefined
-                }
-                onChange={(event) => {
-                  setCombatElement(event.target.value);
-                  setRecommendation(null);
-                }}
-              />
-
-              {combatElementIsInvalid && (
-                <p
-                  id="combat-element-required"
-                  className="text-sm font-medium text-destructive"
+            {selectedWorksheet?.fields.combatElement && (
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor="combat-element"
+                  className="pb-1 text-sm font-medium"
                 >
-                  Required
-                </p>
-              )}
-            </div>
+                  {selectedWorksheet.fields.combatElement.label}
+                </label>
 
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="operation-title"
-                className="pb-1 text-sm font-medium"
-              >
-                Operation Title
-              </label>
-
-              <Input
-                id="operation-title"
-                type="text"
-                value={operationTitle}
-                placeholder="Overlord"
-                aria-invalid={operationTitleIsInvalid ? "true" : undefined}
-                aria-describedby={
-                  operationTitleIsInvalid
-                    ? "operation-title-required"
-                    : undefined
-                }
-                className={
-                  operationTitleIsInvalid
-                    ? "border-destructive focus-visible:ring-destructive"
-                    : undefined
-                }
-                onChange={(event) => {
-                  setOperationTitle(event.target.value);
-                  setRecommendation(null);
-                }}
-              />
-
-              {operationTitleIsInvalid && (
-                <p
-                  id="operation-title-required"
-                  className="text-sm font-medium text-destructive"
-                >
-                  Required
-                </p>
-              )}
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label htmlFor="location" className="pb-1 text-sm font-medium">
-                Location
-              </label>
-
-              <Input
-                id="location"
-                type="text"
-                value={location}
-                placeholder="Omaha Beach"
-                aria-invalid={locationIsInvalid ? "true" : undefined}
-                aria-describedby={
-                  locationIsInvalid ? "location-required" : undefined
-                }
-                className={
-                  locationIsInvalid
-                    ? "border-destructive focus-visible:ring-destructive"
-                    : undefined
-                }
-                onChange={(event) => {
-                  setLocation(event.target.value);
-                  setRecommendation(null);
-                }}
-              />
-
-              {locationIsInvalid && (
-                <p
-                  id="location-required"
-                  className="text-sm font-medium text-destructive"
-                >
-                  Required
-                </p>
-              )}
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="operation-date"
-                className="pb-1 text-sm font-medium"
-              >
-                Operation Date
-              </label>
-
-              <Input
-                id="operation-date"
-                type="date"
-                value={operationDate}
-                aria-invalid={operationDateIsInvalid ? "true" : undefined}
-                aria-describedby={
-                  operationDateIsInvalid ? "operation-date-required" : undefined
-                }
-                className={
-                  operationDateIsInvalid
-                    ? "border-destructive focus-visible:ring-destructive"
-                    : undefined
-                }
-                onChange={(event) => {
-                  setOperationDate(event.target.value);
-                  setRecommendation(null);
-                }}
-              />
-
-              {operationDateIsInvalid && (
-                <p
-                  id="operation-date-required"
-                  className="text-sm font-medium text-destructive"
-                >
-                  {operationDateErrorMessage}
-                </p>
-              )}
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label htmlFor="narrative" className="pb-1 text-sm font-medium">
-                Narrative
-              </label>
-
-              <textarea
-                id="narrative"
-                value={narrative}
-                placeholder="Explain the lead-up, actions, and outcome..."
-                aria-invalid={narrativeIsInvalid ? "true" : undefined}
-                aria-describedby={
-                  narrativeIsInvalid
-                    ? "narrative-required"
-                    : hasNarrativeWarnings
-                      ? "narrative-warnings"
+                <Input
+                  id="combat-element"
+                  type="text"
+                  value={combatElement}
+                  placeholder={
+                    selectedWorksheet.fields.combatElement.placeholder
+                  }
+                  aria-invalid={combatElementIsInvalid ? "true" : undefined}
+                  aria-describedby={
+                    combatElementIsInvalid
+                      ? "combat-element-required"
                       : undefined
-                }
-                onChange={(event) => {
-                  setNarrative(event.target.value);
-                  setRecommendation(null);
-                }}
-                rows={8}
-                className={`flex w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
-                  narrativeIsInvalid
-                    ? "border-destructive focus-visible:ring-destructive"
-                    : hasNarrativeWarnings
-                      ? "border-amber-500/50 focus-visible:ring-amber-500/30"
-                      : "border-input"
-                }`}
-              />
+                  }
+                  className={
+                    combatElementIsInvalid
+                      ? "border-destructive focus-visible:ring-destructive"
+                      : undefined
+                  }
+                  onChange={(event) => {
+                    setCombatElement(event.target.value);
+                    setRecommendation(null);
+                  }}
+                />
 
-              {narrativeIsInvalid && (
-                <p
-                  id="narrative-required"
-                  className="text-sm font-medium text-destructive"
-                >
-                  Required
-                </p>
-              )}
+                {combatElementIsInvalid && (
+                  <p
+                    id="combat-element-required"
+                    className="text-sm font-medium text-destructive"
+                  >
+                    Required
+                  </p>
+                )}
+              </div>
+            )}
 
-              {hasNarrativeWarnings && (
-                <div
-                  id="narrative-warnings"
-                  role="status"
-                  aria-label="Narrative Warnings"
-                  className="space-y-1 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+            {selectedWorksheet?.fields.operationTitle && (
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor="operation-title"
+                  className="pb-1 text-sm font-medium"
                 >
-                  {recommendation.narrativeWarnings.map((warning) => (
-                    <p key={warning.key}>{warning.message}</p>
-                  ))}
-                </div>
-              )}
-            </div>
+                  {selectedWorksheet.fields.operationTitle.label}
+                </label>
+
+                <Input
+                  id="operation-title"
+                  type="text"
+                  value={operationTitle}
+                  placeholder={
+                    selectedWorksheet.fields.operationTitle.placeholder
+                  }
+                  aria-invalid={operationTitleIsInvalid ? "true" : undefined}
+                  aria-describedby={
+                    operationTitleIsInvalid
+                      ? "operation-title-required"
+                      : undefined
+                  }
+                  className={
+                    operationTitleIsInvalid
+                      ? "border-destructive focus-visible:ring-destructive"
+                      : undefined
+                  }
+                  onChange={(event) => {
+                    setOperationTitle(event.target.value);
+                    setRecommendation(null);
+                  }}
+                />
+
+                {operationTitleIsInvalid && (
+                  <p
+                    id="operation-title-required"
+                    className="text-sm font-medium text-destructive"
+                  >
+                    Required
+                  </p>
+                )}
+              </div>
+            )}
+
+            {selectedWorksheet?.fields.location && (
+              <div className="flex flex-col gap-2">
+                <label htmlFor="location" className="pb-1 text-sm font-medium">
+                  {selectedWorksheet.fields.location.label}
+                </label>
+
+                <Input
+                  id="location"
+                  type="text"
+                  value={location}
+                  placeholder={selectedWorksheet.fields.location.placeholder}
+                  aria-invalid={locationIsInvalid ? "true" : undefined}
+                  aria-describedby={
+                    locationIsInvalid ? "location-required" : undefined
+                  }
+                  className={
+                    locationIsInvalid
+                      ? "border-destructive focus-visible:ring-destructive"
+                      : undefined
+                  }
+                  onChange={(event) => {
+                    setLocation(event.target.value);
+                    setRecommendation(null);
+                  }}
+                />
+
+                {locationIsInvalid && (
+                  <p
+                    id="location-required"
+                    className="text-sm font-medium text-destructive"
+                  >
+                    Required
+                  </p>
+                )}
+              </div>
+            )}
+
+            {selectedWorksheet?.fields.operationDate && (
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor="operation-date"
+                  className="pb-1 text-sm font-medium"
+                >
+                  {selectedWorksheet.fields.operationDate.label}
+                </label>
+
+                <Input
+                  id="operation-date"
+                  type="date"
+                  value={operationDate}
+                  aria-invalid={operationDateIsInvalid ? "true" : undefined}
+                  aria-describedby={
+                    operationDateIsInvalid
+                      ? "operation-date-required"
+                      : undefined
+                  }
+                  className={
+                    operationDateIsInvalid
+                      ? "border-destructive focus-visible:ring-destructive"
+                      : undefined
+                  }
+                  onChange={(event) => {
+                    setOperationDate(event.target.value);
+                    setRecommendation(null);
+                  }}
+                />
+
+                {operationDateIsInvalid && (
+                  <p
+                    id="operation-date-required"
+                    className="text-sm font-medium text-destructive"
+                  >
+                    {operationDateErrorMessage}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {selectedWorksheet?.fields.narrative && (
+              <div className="flex flex-col gap-2">
+                <label htmlFor="narrative" className="pb-1 text-sm font-medium">
+                  {selectedWorksheet.fields.narrative.label}
+                </label>
+
+                <textarea
+                  id="narrative"
+                  value={narrative}
+                  placeholder={selectedWorksheet.fields.narrative.placeholder}
+                  aria-invalid={narrativeIsInvalid ? "true" : undefined}
+                  aria-describedby={
+                    narrativeIsInvalid
+                      ? "narrative-required"
+                      : hasNarrativeWarnings
+                        ? "narrative-warnings"
+                        : undefined
+                  }
+                  onChange={(event) => {
+                    setNarrative(event.target.value);
+                    setRecommendation(null);
+                  }}
+                  rows={8}
+                  className={`flex w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                    narrativeIsInvalid
+                      ? "border-destructive focus-visible:ring-destructive"
+                      : hasNarrativeWarnings
+                        ? "border-amber-500/50 focus-visible:ring-amber-500/30"
+                        : "border-input"
+                  }`}
+                />
+
+                {narrativeIsInvalid && (
+                  <p
+                    id="narrative-required"
+                    className="text-sm font-medium text-destructive"
+                  >
+                    Required
+                  </p>
+                )}
+
+                {hasNarrativeWarnings && (
+                  <div
+                    id="narrative-warnings"
+                    role="status"
+                    aria-label="Narrative Warnings"
+                    className="space-y-1 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+                  >
+                    {recommendation.narrativeWarnings.map((warning) => (
+                      <p key={warning.key}>{warning.message}</p>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
 
             <Button type="button" onClick={handleGenerate}>
               Generate Recommendation

--- a/client/app/medalrecommendation/lib/citation-builders.js
+++ b/client/app/medalrecommendation/lib/citation-builders.js
@@ -1,0 +1,146 @@
+export function buildEntireOperationActionOpening({
+  actionCharacter,
+  combatElement,
+  operationTitle,
+  location,
+  date,
+}) {
+  return (
+    `For ${actionCharacter} actions over an entire operation while serving as ` +
+    `${combatElement} in the 7th Cavalry Regiment during combat in ` +
+    `Operation ${operationTitle} near ${location} on ${date}.`
+  );
+}
+
+export function buildActionCharacterCreditClosing({
+  recipientRank,
+  recipientCitationName,
+  actionCharacter,
+}) {
+  return (
+    `${recipientRank} ${recipientCitationName}'s ${actionCharacter} actions ` +
+    "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
+  );
+}
+
+export function buildGallantryOpening({
+  combatElement,
+  operationTitle,
+  location,
+  date,
+}) {
+  return (
+    "For conspicuous gallantry and intrepidity under direct enemy fire while serving as " +
+    `${combatElement} in the 7th Cavalry Regiment during combat in ` +
+    `Operation ${operationTitle} near ${location} on ${date}.`
+  );
+}
+
+export function buildHeroismSkillDevotionClosing({
+  recipientRank,
+  recipientCitationName,
+}) {
+  return (
+    `${recipientRank} ${recipientCitationName}'s heroism, skill and devotion to duty ` +
+    "reflects great credit upon themselves and the 7th Cavalry Gaming Regiment."
+  );
+}
+
+export function buildSkillsAndHeroicActionsClosing({
+  recipientRank,
+  recipientCitationName,
+}) {
+  return (
+    `${recipientRank} ${recipientCitationName}'s skills and heroic actions ` +
+    "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
+  );
+}
+
+export function buildSingleHeroismAndSkillOpening({
+  combatElement,
+  operationTitle,
+  location,
+  date,
+}) {
+  return (
+    "For a single act of heroism and skill under enemy fire while serving as " +
+    `${combatElement} in the 7th Cavalry Regiment during combat in ` +
+    `Operation ${operationTitle} near ${location} on ${date}.`
+  );
+}
+
+export function buildHeroismAndSkillClosing({
+  recipientRank,
+  recipientCitationName,
+}) {
+  return (
+    `${recipientRank} ${recipientCitationName}'s heroism and skill ` +
+    "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
+  );
+}
+
+export function buildPurpleHeartOpening({
+  scope,
+  combatElement,
+  operationTitle,
+  location,
+  date,
+}) {
+  let actionText;
+
+  switch (scope) {
+    case "single":
+      actionText = "a single heroic action";
+      break;
+
+    case "multiple":
+      actionText = "multiple heroic actions";
+      break;
+
+    default:
+      throw new Error(`Unsupported Purple Heart scope: ${scope}`);
+  }
+
+  return (
+    `For ${actionText} and skill under enemy fire resulting in their ` +
+    `sacrifice and death while serving as ${combatElement} in the 7th Cavalry ` +
+    `Regiment during combat in Operation ${operationTitle} near ${location} ` +
+    `on ${date}.`
+  );
+}
+
+export function buildHeroismAndSacrificeClosing({
+  recipientRank,
+  recipientCitationName,
+}) {
+  return (
+    `${recipientRank} ${recipientCitationName}'s heroism and sacrifice ` +
+    "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
+  );
+}
+
+export function buildExtraordinaryHeroismOpening({
+  combatElement,
+  operationTitle,
+  location,
+  date,
+}) {
+  return (
+    "For a single act demonstrating extraordinary heroism and skill under enemy fire " +
+    `while serving as ${combatElement} in the 7th Cavalry Regiment during combat in ` +
+    `Operation ${operationTitle} near ${location} on ${date}.`
+  );
+}
+
+export function buildExtraordinaryHeroismPilotOpening({
+  combatElement,
+  operationTitle,
+  location,
+  date,
+}) {
+  return (
+    "For a single act demonstrating extraordinary heroism and skill under enemy fire " +
+    `while serving as ${combatElement} pilot in the 7th Cavalry Regiment during combat in ` +
+    `Operation ${operationTitle} near ${location} on ${date}.`
+  );
+}

--- a/client/app/medalrecommendation/lib/medal-definitions.js
+++ b/client/app/medalrecommendation/lib/medal-definitions.js
@@ -1,8 +1,23 @@
+import {
+  buildActionCharacterCreditClosing,
+  buildEntireOperationActionOpening,
+  buildExtraordinaryHeroismOpening,
+  buildExtraordinaryHeroismPilotOpening,
+  buildGallantryOpening,
+  buildHeroismAndSacrificeClosing,
+  buildHeroismAndSkillClosing,
+  buildHeroismSkillDevotionClosing,
+  buildPurpleHeartOpening,
+  buildSingleHeroismAndSkillOpening,
+  buildSkillsAndHeroicActionsClosing,
+} from "./citation-builders.js";
+
 export const OPERATION_MEDALS = [
   {
     id: "army-commendation-medal",
     name: "Army Commendation Medal",
     abbreviation: "ARCOM",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/d/dc/ARCOM.jpg",
 
     criteria:
@@ -14,53 +29,36 @@ export const OPERATION_MEDALS = [
     minimumNarrativeSentences: 3,
 
     fields: {
-      actionCharacter: true,
-      scope: false,
-      combatElementLabel: "Combat Element",
-      combatElementPlaceholder: "a rifleman, the Allied commander, etc.",
+      actionCharacter: {
+        type: "citationChoice",
+        required: true,
+        options: [
+          {
+            id: "skillful",
+            label: "Skillful",
+            citationText: "skillful",
+          },
+          {
+            id: "heroic",
+            label: "Heroic",
+            citationText: "heroic",
+          },
+        ],
+      },
     },
-
-    actionCharacterOptions: [
-      {
-        value: "skillful",
-        label: "Skillful",
-      },
-      {
-        value: "heroic",
-        label: "Heroic",
-      },
-    ],
-
-    scopeOptions: [],
 
     eligibilityNotes: [],
 
-    buildOpening({
-      actionCharacter,
-      combatElement,
-      operationTitle,
-      location,
-      date,
-    }) {
-      return (
-        `For ${actionCharacter} actions over an entire operation while serving as ` +
-        `${combatElement} in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildEntireOperationActionOpening,
 
-    buildClosing({ recipientRank, recipientCitationName, actionCharacter }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s ${actionCharacter} actions ` +
-        "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildActionCharacterCreditClosing,
   },
 
   {
     id: "army-commendation-medal-with-valor",
     name: "Army Commendation Medal With Valor",
     abbreviation: "ARCOMV",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/0/0f/ARCOMV.jpg",
 
     criteria: "Awarded for a single act of heroism or skill under fire.",
@@ -70,37 +68,18 @@ export const OPERATION_MEDALS = [
 
     minimumNarrativeSentences: 3,
 
-    fields: {
-      actionCharacter: false,
-      scope: false,
-      combatElementLabel: "Combat Element",
-      combatElementPlaceholder: "a rifleman, the Allied commander, etc.",
-    },
-
-    actionCharacterOptions: [],
-    scopeOptions: [],
     eligibilityNotes: [],
 
-    buildOpening({ combatElement, operationTitle, location, date }) {
-      return (
-        "For a single act of heroism and skill under enemy fire while serving as " +
-        `${combatElement} in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildSingleHeroismAndSkillOpening,
 
-    buildClosing({ recipientRank, recipientCitationName }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s heroism and skill ` +
-        "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildHeroismAndSkillClosing,
   },
 
   {
     id: "air-medal",
     name: "Air Medal",
     abbreviation: "AM",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/3/3f/AM.jpg",
 
     criteria:
@@ -112,55 +91,41 @@ export const OPERATION_MEDALS = [
     minimumNarrativeSentences: 3,
 
     fields: {
-      actionCharacter: true,
-      scope: false,
+      actionCharacter: {
+        type: "citationChoice",
+        required: true,
+        options: [
+          {
+            id: "skillful",
+            label: "Skillful",
+            citationText: "skillful",
+          },
+          {
+            id: "heroic",
+            label: "Heroic",
+            citationText: "heroic",
+          },
+        ],
+      },
+      combatElementVariant: "aircrew",
       combatElementLabel: "Aircrew Combat Element",
       combatElementPlaceholder: "a door gunner, an F-16 pilot, etc.",
     },
-
-    actionCharacterOptions: [
-      {
-        value: "skillful",
-        label: "Skillful",
-      },
-      {
-        value: "heroic",
-        label: "Heroic",
-      },
-    ],
-
-    scopeOptions: [],
 
     eligibilityNotes: [
       "The recipient must be a member of an aircrew. Pilots are eligible.",
     ],
 
-    buildOpening({
-      actionCharacter,
-      combatElement,
-      operationTitle,
-      location,
-      date,
-    }) {
-      return (
-        `For ${actionCharacter} actions over an entire operation while serving as ` +
-        `${combatElement} in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildEntireOperationActionOpening,
 
-    buildClosing({ recipientRank, recipientCitationName, actionCharacter }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s ${actionCharacter} actions ` +
-        "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildActionCharacterCreditClosing,
   },
 
   {
     id: "purple-heart",
     name: "Purple Heart",
     abbreviation: "PH",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/b/b5/PH.jpg",
 
     criteria:
@@ -172,55 +137,36 @@ export const OPERATION_MEDALS = [
     minimumNarrativeSentences: 3,
 
     fields: {
-      actionCharacter: false,
-      scope: true,
-      combatElementLabel: "Combat Element",
-      combatElementPlaceholder: "a rifleman, the Allied commander, etc.",
+      scope: {
+        type: "scopeChoice",
+        required: true,
+        options: [
+          {
+            id: "single",
+            label: "Single",
+          },
+          {
+            id: "multiple",
+            label: "Multiple",
+          },
+        ],
+      },
     },
-
-    actionCharacterOptions: [],
-
-    scopeOptions: [
-      {
-        value: "single",
-        label: "Single",
-      },
-      {
-        value: "multiple",
-        label: "Multiple",
-      },
-    ],
 
     eligibilityNotes: [
       "The recipient must have been killed while undertaking the combat actions being cited.",
     ],
 
-    buildOpening({ scope, combatElement, operationTitle, location, date }) {
-      const actionText =
-        scope === "single"
-          ? "a single heroic action"
-          : "multiple heroic actions";
+    buildOpening: buildPurpleHeartOpening,
 
-      return (
-        `For ${actionText} and skill under enemy fire resulting in their ` +
-        `sacrifice and death while serving as ${combatElement} in the 7th Cavalry ` +
-        `Regiment during combat in Operation ${operationTitle} near ${location} ` +
-        `on ${date}.`
-      );
-    },
-
-    buildClosing({ recipientRank, recipientCitationName }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s heroism and sacrifice ` +
-        "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildHeroismAndSacrificeClosing,
   },
 
   {
     id: "bronze-star-medal",
     name: "Bronze Star Medal",
     abbreviation: "BS",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/5/5e/BS.jpg",
 
     criteria:
@@ -232,52 +178,36 @@ export const OPERATION_MEDALS = [
     minimumNarrativeSentences: 3,
 
     fields: {
-      actionCharacter: true,
-      scope: false,
-      combatElementLabel: "Combat Element",
-      combatElementPlaceholder: "a rifleman, the Allied commander, etc.",
+      actionCharacter: {
+        type: "citationChoice",
+        required: true,
+        options: [
+          {
+            id: "skillful",
+            label: "Skillful",
+            citationText: "skillful",
+          },
+          {
+            id: "heroic",
+            label: "Heroic",
+            citationText: "heroic",
+          },
+        ],
+      },
     },
 
-    actionCharacterOptions: [
-      {
-        value: "skillful",
-        label: "Skillful",
-      },
-      {
-        value: "heroic",
-        label: "Heroic",
-      },
-    ],
-
-    scopeOptions: [],
     eligibilityNotes: [],
 
-    buildOpening({
-      actionCharacter,
-      combatElement,
-      operationTitle,
-      location,
-      date,
-    }) {
-      return (
-        `For ${actionCharacter} actions over an entire operation while serving as ` +
-        `${combatElement} in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildEntireOperationActionOpening,
 
-    buildClosing({ recipientRank, recipientCitationName, actionCharacter }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s ${actionCharacter} actions ` +
-        "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildActionCharacterCreditClosing,
   },
 
   {
     id: "bronze-star-medal-with-valor",
     name: "Bronze Star Medal With Valor",
     abbreviation: "BSV",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/8/88/BSV.jpg",
 
     criteria:
@@ -288,40 +218,20 @@ export const OPERATION_MEDALS = [
 
     minimumNarrativeSentences: 3,
 
-    fields: {
-      actionCharacter: false,
-      scope: false,
-      combatElementLabel: "Combat Element",
-      combatElementPlaceholder: "a rifleman, the Allied commander, etc.",
-    },
-
-    actionCharacterOptions: [],
-    scopeOptions: [],
-
     eligibilityNotes: [
       "The recipient must have survived the cited action to be eligible for this award.",
     ],
 
-    buildOpening({ combatElement, operationTitle, location, date }) {
-      return (
-        "For a single act demonstrating extraordinary heroism and skill under enemy fire " +
-        `while serving as ${combatElement} in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildExtraordinaryHeroismOpening,
 
-    buildClosing({ recipientRank, recipientCitationName }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s skills and heroic actions ` +
-        "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildSkillsAndHeroicActionsClosing,
   },
 
   {
     id: "distinguished-flying-cross",
     name: "Distinguished Flying Cross",
     abbreviation: "DFC",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/7/74/DFC.jpg",
 
     criteria:
@@ -333,14 +243,10 @@ export const OPERATION_MEDALS = [
     minimumNarrativeSentences: 3,
 
     fields: {
-      actionCharacter: false,
-      scope: false,
+      combatElementVariant: "airframe",
       combatElementLabel: "Airframe",
       combatElementPlaceholder: "an F/A-18, a Rotary-Wing, etc.",
     },
-
-    actionCharacterOptions: [],
-    scopeOptions: [],
 
     eligibilityNotes: [
       "The recipient must be a pilot.",
@@ -349,26 +255,16 @@ export const OPERATION_MEDALS = [
       "The recipient must have survived the cited action.",
     ],
 
-    buildOpening({ combatElement, operationTitle, location, date }) {
-      return (
-        "For a single act demonstrating extraordinary heroism and skill under enemy fire " +
-        `while serving as ${combatElement} pilot in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildExtraordinaryHeroismPilotOpening,
 
-    buildClosing({ recipientRank, recipientCitationName }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s skills and heroic actions ` +
-        "reflect great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildSkillsAndHeroicActionsClosing,
   },
 
   {
     id: "silver-star",
     name: "Silver Star",
     abbreviation: "SS",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/8/8f/SS.jpg",
 
     criteria:
@@ -380,40 +276,26 @@ export const OPERATION_MEDALS = [
     minimumNarrativeSentences: 4,
 
     fields: {
-      actionCharacter: false,
-      scope: false,
+      combatElementVariant: "leadership",
       combatElementLabel: "Leadership Element",
       combatElementPlaceholder: "a platoon leader, commander, etc.",
     },
-
-    actionCharacterOptions: [],
-    scopeOptions: [],
 
     eligibilityNotes: [
       "The recipient must have been serving in an official leadership position.",
       "The recipient must have survived the cited action.",
     ],
 
-    buildOpening({ combatElement, operationTitle, location, date }) {
-      return (
-        "For conspicuous gallantry and intrepidity under direct enemy fire while serving as " +
-        `${combatElement} in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildGallantryOpening,
 
-    buildClosing({ recipientRank, recipientCitationName }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s heroism, skill and devotion to duty ` +
-        "reflects great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildHeroismSkillDevotionClosing,
   },
 
   {
     id: "distinguished-service-cross",
     name: "Distinguished Service Cross",
     abbreviation: "DSC",
+    worksheetProfile: "operationIndividual",
     ribbonUrl: "https://wiki.7cav.us/images/d/d3/DSC.jpg",
 
     criteria:
@@ -424,36 +306,15 @@ export const OPERATION_MEDALS = [
 
     minimumNarrativeSentences: 5,
 
-    fields: {
-      actionCharacter: false,
-      scope: false,
-      combatElementLabel: "Combat Element",
-      combatElementPlaceholder: "a rifleman, the Allied commander, etc.",
-    },
-
-    actionCharacterOptions: [],
-    scopeOptions: [],
-
     eligibilityNotes: [
       "The recipient must have survived the cited action.",
       "Against a live enemy (non-Cav) force or in an internal player-versus-player match, the cited actions must have been unquestionably responsible for the successful outcome of the mission.",
       "Against a computer opponent, the recipient must have been serving as Officer-In-Command (OIC) of the official operation and their actions must have been unquestionably responsible for the successful outcome of the mission.",
     ],
 
-    buildOpening({ combatElement, operationTitle, location, date }) {
-      return (
-        "For conspicuous gallantry and intrepidity under direct enemy fire while serving as " +
-        `${combatElement} in the 7th Cavalry Regiment during combat in ` +
-        `Operation ${operationTitle} near ${location} on ${date}.`
-      );
-    },
+    buildOpening: buildGallantryOpening,
 
-    buildClosing({ recipientRank, recipientCitationName }) {
-      return (
-        `${recipientRank} ${recipientCitationName}'s heroism, skill and devotion to duty ` +
-        "reflects great credit upon themselves and the 7th Cavalry Gaming Regiment."
-      );
-    },
+    buildClosing: buildHeroismSkillDevotionClosing,
   },
 ];
 

--- a/client/app/medalrecommendation/lib/worksheet-profiles.js
+++ b/client/app/medalrecommendation/lib/worksheet-profiles.js
@@ -1,0 +1,165 @@
+export const WORKSHEET_PROFILES = {
+  operationIndividual: {
+    recipientType: "individual",
+
+    fields: {
+      combatElement: {
+        type: "text",
+        variant: "combat",
+        required: true,
+        label: "Combat Element",
+        placeholder: "a rifleman, the Allied commander, etc.",
+        awardChange: "sameVariant",
+      },
+
+      operationTitle: {
+        type: "text",
+        required: true,
+        label: "Operation Title",
+        placeholder: "Overlord",
+        awardChange: "preserve",
+      },
+
+      location: {
+        type: "text",
+        required: true,
+        label: "Location",
+        placeholder: "Omaha Beach",
+        awardChange: "preserve",
+      },
+
+      operationDate: {
+        type: "date",
+        required: true,
+        label: "Operation Date",
+        awardChange: "preserve",
+      },
+
+      narrative: {
+        type: "textarea",
+        required: true,
+        label: "Narrative",
+        placeholder: "Explain the lead-up, actions, and outcome...",
+        awardChange: "preserve",
+      },
+    },
+  },
+};
+
+function copyFields(fields) {
+  return Object.fromEntries(
+    Object.entries(fields).map(([fieldName, field]) => [
+      fieldName,
+      { ...field },
+    ]),
+  );
+}
+
+export function resolveMedalWorksheet(medal) {
+  if (!medal) {
+    return null;
+  }
+
+  const profile = WORKSHEET_PROFILES[medal.worksheetProfile];
+
+  if (!profile) {
+    return null;
+  }
+
+  const fields = copyFields(profile.fields);
+
+  fields.combatElement = {
+    ...fields.combatElement,
+    variant: medal.fields?.combatElementVariant ?? fields.combatElement.variant,
+    label: medal.fields?.combatElementLabel ?? fields.combatElement.label,
+    placeholder:
+      medal.fields?.combatElementPlaceholder ??
+      fields.combatElement.placeholder,
+  };
+
+  if (medal.fields?.actionCharacter) {
+    fields.actionCharacter = {
+      ...medal.fields.actionCharacter,
+      awardChange: "reset",
+      options: medal.fields.actionCharacter.options.map((option) => ({
+        ...option,
+      })),
+    };
+  }
+
+  if (medal.fields?.scope) {
+    fields.scope = {
+      ...medal.fields.scope,
+      awardChange: "reset",
+      options: medal.fields.scope.options.map((option) => ({
+        ...option,
+      })),
+    };
+  }
+
+  return {
+    recipientType: profile.recipientType,
+    fields,
+  };
+}
+
+export function getCitationChoiceText(field, choiceId) {
+  const option = field?.options?.find((entry) => entry.id === choiceId);
+
+  if (
+    field?.type !== "citationChoice" ||
+    !option ||
+    typeof option.citationText !== "string" ||
+    !option.citationText
+  ) {
+    throw new Error(`Unsupported citation choice: ${choiceId}`);
+  }
+
+  return option.citationText;
+}
+
+export function applyAwardChange(
+  previousWorksheet,
+  nextWorksheet,
+  currentValues,
+) {
+  const nextValues = { ...currentValues };
+
+  const fieldNames = new Set([
+    ...Object.keys(previousWorksheet?.fields ?? {}),
+    ...Object.keys(nextWorksheet?.fields ?? {}),
+  ]);
+
+  for (const fieldName of fieldNames) {
+    const previousField = previousWorksheet?.fields?.[fieldName];
+    const nextField = nextWorksheet?.fields?.[fieldName];
+
+    const awardChange = nextField?.awardChange ?? previousField?.awardChange;
+
+    switch (awardChange) {
+      case "preserve":
+        break;
+
+      case "reset":
+        nextValues[fieldName] = "";
+        break;
+
+      case "sameVariant":
+        if (
+          !previousField ||
+          !nextField ||
+          previousField.variant !== nextField.variant
+        ) {
+          nextValues[fieldName] = "";
+        }
+        break;
+
+      default:
+        throw new Error(
+          `Unsupported award-change policy for field "${fieldName}"`,
+        );
+    }
+  }
+
+  return nextValues;
+}

--- a/client/app/medalrecommendation/lib/worksheet-validation.js
+++ b/client/app/medalrecommendation/lib/worksheet-validation.js
@@ -1,0 +1,70 @@
+export function isOperationDateValid(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return false;
+  }
+
+  const now = new Date();
+  const localToday = [
+    String(now.getFullYear()).padStart(4, "0"),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("-");
+
+  return value <= localToday;
+}
+
+function validateField(field, value) {
+  if (!field.required) {
+    return true;
+  }
+
+  switch (field.type) {
+    case "text":
+    case "textarea":
+      return typeof value === "string" && Boolean(value.trim());
+
+    case "date":
+      return isOperationDateValid(value);
+
+    case "citationChoice":
+    case "scopeChoice":
+      return (
+        Array.isArray(field.options) &&
+        field.options.some((option) => option.id === value)
+      );
+
+    default:
+      return false;
+  }
+}
+
+export function validateWorksheet(worksheet, values = {}) {
+  if (!worksheet?.fields) {
+    return {
+      fields: {},
+      isComplete: false,
+    };
+  }
+
+  const fields = {};
+
+  for (const [fieldName, field] of Object.entries(worksheet.fields)) {
+    fields[fieldName] = validateField(field, values[fieldName]);
+  }
+
+  return {
+    fields,
+    isComplete: Object.values(fields).every(Boolean),
+  };
+}

--- a/client/app/medalrecommendation/tests/worksheet-profiles.test.js
+++ b/client/app/medalrecommendation/tests/worksheet-profiles.test.js
@@ -1,0 +1,371 @@
+import { OPERATION_MEDALS } from "../lib/medal-definitions.js";
+import { resolveMedalWorksheet } from "../lib/worksheet-profiles.js";
+import {
+  applyAwardChange,
+  resolveMedalWorksheet,
+} from "../lib/worksheet-profiles.js";
+import {
+  applyAwardChange,
+  getCitationChoiceText,
+  resolveMedalWorksheet,
+} from "../lib/worksheet-profiles.js";
+
+function getMedal(name) {
+  return OPERATION_MEDALS.find((medal) => medal.name === name);
+}
+
+describe("Medal Recommendation Aid - worksheet profiles", () => {
+  test("resolves the shared Operation worksheet for ARCOM", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    expect(worksheet.recipientType).toBe("individual");
+
+    expect(worksheet.fields.combatElement).toMatchObject({
+      type: "text",
+      variant: "combat",
+      required: true,
+      label: "Combat Element",
+      placeholder: "a rifleman, the Allied commander, etc.",
+    });
+
+    expect(worksheet.fields.operationTitle).toMatchObject({
+      type: "text",
+      required: true,
+      label: "Operation Title",
+    });
+
+    expect(worksheet.fields.location).toMatchObject({
+      type: "text",
+      required: true,
+      label: "Location",
+    });
+
+    expect(worksheet.fields.operationDate).toMatchObject({
+      type: "date",
+      required: true,
+      label: "Operation Date",
+    });
+
+    expect(worksheet.fields.narrative).toMatchObject({
+      type: "textarea",
+      required: true,
+      label: "Narrative",
+    });
+
+    expect(worksheet.fields.actionCharacter).toBeDefined();
+    expect(worksheet.fields.scope).toBeUndefined();
+  });
+
+  test("overrides only the element configuration needed by DFC", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Distinguished Flying Cross"),
+    );
+
+    expect(worksheet.fields.combatElement).toMatchObject({
+      type: "text",
+      variant: "airframe",
+      required: true,
+      label: "Airframe",
+      placeholder: "an F/A-18, a Rotary-Wing, etc.",
+    });
+
+    expect(worksheet.fields.operationTitle.label).toBe("Operation Title");
+    expect(worksheet.fields.location.label).toBe("Location");
+    expect(worksheet.fields.operationDate.label).toBe("Operation Date");
+    expect(worksheet.fields.narrative.label).toBe("Narrative");
+
+    expect(worksheet.fields.actionCharacter).toBeUndefined();
+    expect(worksheet.fields.scope).toBeUndefined();
+  });
+
+  test.each([
+    ["Army Commendation Medal", "combat"],
+    ["Army Commendation Medal With Valor", "combat"],
+    ["Air Medal", "aircrew"],
+    ["Purple Heart", "combat"],
+    ["Bronze Star Medal", "combat"],
+    ["Bronze Star Medal With Valor", "combat"],
+    ["Distinguished Flying Cross", "airframe"],
+    ["Silver Star", "leadership"],
+    ["Distinguished Service Cross", "combat"],
+  ])(
+    "%s resolves the correct worksheet profile and combat element semantics",
+    (medalName, combatElementVariant) => {
+      const medal = getMedal(medalName);
+      const worksheet = resolveMedalWorksheet(medal);
+
+      expect(medal.worksheetProfile).toBe("operationIndividual");
+      expect(worksheet.fields.combatElement.variant).toBe(combatElementVariant);
+    },
+  );
+
+  test("declares award-change behavior for shared Operation fields", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    expect(worksheet.fields.combatElement.awardChange).toBe("sameVariant");
+    expect(worksheet.fields.operationTitle.awardChange).toBe("preserve");
+    expect(worksheet.fields.location.awardChange).toBe("preserve");
+    expect(worksheet.fields.operationDate.awardChange).toBe("preserve");
+    expect(worksheet.fields.narrative.awardChange).toBe("preserve");
+  });
+
+  test("declares medal-specific choices to reset when the award changes", () => {
+    const arcomWorksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const purpleHeartWorksheet = resolveMedalWorksheet(
+      getMedal("Purple Heart"),
+    );
+
+    expect(arcomWorksheet.fields.actionCharacter.awardChange).toBe("reset");
+    expect(purpleHeartWorksheet.fields.scope.awardChange).toBe("reset");
+  });
+
+  test("preserves shared Operation values when changing between compatible medals", () => {
+    const previousWorksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const nextWorksheet = resolveMedalWorksheet(getMedal("Bronze Star Medal"));
+
+    const values = {
+      actionCharacter: "skillful",
+      scope: "",
+      combatElement: "a rifleman",
+      operationTitle: "Overlord",
+      location: "Remagen",
+      operationDate: "2026-08-11",
+      narrative: "Existing narrative",
+    };
+
+    expect(applyAwardChange(previousWorksheet, nextWorksheet, values)).toEqual({
+      actionCharacter: "",
+      scope: "",
+      combatElement: "a rifleman",
+      operationTitle: "Overlord",
+      location: "Remagen",
+      operationDate: "2026-08-11",
+      narrative: "Existing narrative",
+    });
+  });
+
+  test("clears the combat element when its semantic variant changes", () => {
+    const previousWorksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const nextWorksheet = resolveMedalWorksheet(
+      getMedal("Distinguished Flying Cross"),
+    );
+
+    const values = {
+      actionCharacter: "",
+      scope: "",
+      combatElement: "a rifleman",
+      operationTitle: "Overlord",
+      location: "Remagen",
+      operationDate: "2026-08-11",
+      narrative: "Existing narrative",
+    };
+
+    expect(
+      applyAwardChange(previousWorksheet, nextWorksheet, values),
+    ).toMatchObject({
+      combatElement: "",
+      operationTitle: "Overlord",
+      location: "Remagen",
+      operationDate: "2026-08-11",
+      narrative: "Existing narrative",
+    });
+  });
+
+  test("clears Scope when leaving Purple Heart", () => {
+    const previousWorksheet = resolveMedalWorksheet(getMedal("Purple Heart"));
+
+    const nextWorksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const values = {
+      actionCharacter: "",
+      scope: "single",
+      combatElement: "a rifleman",
+      operationTitle: "Overlord",
+      location: "Remagen",
+      operationDate: "2026-08-11",
+      narrative: "Existing narrative",
+    };
+
+    expect(
+      applyAwardChange(previousWorksheet, nextWorksheet, values),
+    ).toMatchObject({
+      scope: "",
+      combatElement: "a rifleman",
+    });
+  });
+
+  test("declares presentation metadata for shared Operation fields", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    expect(worksheet.fields.operationTitle).toMatchObject({
+      label: "Operation Title",
+      placeholder: "Overlord",
+    });
+
+    expect(worksheet.fields.location).toMatchObject({
+      label: "Location",
+      placeholder: "Omaha Beach",
+    });
+
+    expect(worksheet.fields.operationDate).toMatchObject({
+      label: "Operation Date",
+    });
+
+    expect(worksheet.fields.narrative).toMatchObject({
+      label: "Narrative",
+      placeholder: "Explain the lead-up, actions, and outcome...",
+    });
+  });
+
+  test("declares Action Character options as citation-ready choices", () => {
+    const medal = getMedal("Army Commendation Medal");
+
+    expect(medal.fields.actionCharacter).toEqual({
+      type: "citationChoice",
+      required: true,
+      options: [
+        {
+          id: "skillful",
+          label: "Skillful",
+          citationText: "skillful",
+        },
+        {
+          id: "heroic",
+          label: "Heroic",
+          citationText: "heroic",
+        },
+      ],
+    });
+  });
+
+  test("declares Purple Heart Scope as semantic choices", () => {
+    const medal = getMedal("Purple Heart");
+
+    expect(medal.fields.scope).toEqual({
+      type: "scopeChoice",
+      required: true,
+      options: [
+        {
+          id: "single",
+          label: "Single",
+        },
+        {
+          id: "multiple",
+          label: "Multiple",
+        },
+      ],
+    });
+  });
+
+  test("Purple Heart rejects an unsupported Scope value", () => {
+    const medal = getMedal("Purple Heart");
+
+    expect(() =>
+      medal.buildOpening({
+        scope: "unsupported",
+        combatElement: "a rifleman",
+        operationTitle: "Overlord",
+        location: "Remagen",
+        date: "11 August 2026",
+      }),
+    ).toThrow("Unsupported Purple Heart scope: unsupported");
+  });
+
+  test("resolves citation-ready text independently from a choice id", () => {
+    const field = {
+      type: "citationChoice",
+      options: [
+        {
+          id: "heroic-actions",
+          label: "Heroic",
+          citationText: "heroic",
+        },
+      ],
+    };
+
+    expect(getCitationChoiceText(field, "heroic-actions")).toBe("heroic");
+  });
+
+  test("rejects an unsupported citation choice id", () => {
+    const field = {
+      type: "citationChoice",
+      options: [
+        {
+          id: "heroic-actions",
+          label: "Heroic",
+          citationText: "heroic",
+        },
+      ],
+    };
+
+    expect(() => getCitationChoiceText(field, "unsupported")).toThrow(
+      "Unsupported citation choice: unsupported",
+    );
+  });
+
+  test("fails closed when a medal references an unknown worksheet profile", () => {
+    const worksheet = resolveMedalWorksheet({
+      worksheetProfile: "unsupportedProfile",
+    });
+
+    expect(worksheet).toBeNull();
+  });
+
+  test.each([
+    [undefined, "heroic"],
+    [
+      {
+        type: "citationChoice",
+      },
+      "heroic",
+    ],
+    [
+      {
+        type: "scopeChoice",
+        options: [
+          {
+            id: "heroic",
+            citationText: "heroic",
+          },
+        ],
+      },
+      "heroic",
+    ],
+    [
+      {
+        type: "citationChoice",
+        options: [
+          {
+            id: "heroic",
+            citationText: 123,
+          },
+        ],
+      },
+      "heroic",
+    ],
+  ])(
+    "fails closed for malformed citation-choice configuration",
+    (field, choiceId) => {
+      expect(() => getCitationChoiceText(field, choiceId)).toThrow(
+        `Unsupported citation choice: ${choiceId}`,
+      );
+    },
+  );
+});

--- a/client/app/medalrecommendation/tests/worksheet-validation.test.js
+++ b/client/app/medalrecommendation/tests/worksheet-validation.test.js
@@ -1,0 +1,150 @@
+import { OPERATION_MEDALS } from "../lib/medal-definitions.js";
+import { resolveMedalWorksheet } from "../lib/worksheet-profiles.js";
+import { validateWorksheet } from "../lib/worksheet-validation.js";
+
+function getMedal(name) {
+  return OPERATION_MEDALS.find((medal) => medal.name === name);
+}
+
+function completeOperationValues(overrides = {}) {
+  return {
+    actionCharacter: "skillful",
+    scope: "",
+    combatElement: "a rifleman",
+    operationTitle: "Overlord",
+    location: "Remagen",
+    operationDate: new Date().toLocaleDateString("en-CA"),
+    narrative: "Existing narrative",
+    ...overrides,
+  };
+}
+
+describe("Medal Recommendation Aid - worksheet validation", () => {
+  test("accepts a complete Operation worksheet", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const result = validateWorksheet(worksheet, completeOperationValues());
+
+    expect(result.isComplete).toBe(true);
+
+    expect(result.fields).toMatchObject({
+      combatElement: true,
+      operationTitle: true,
+      location: true,
+      operationDate: true,
+      narrative: true,
+      actionCharacter: true,
+    });
+  });
+
+  test("rejects whitespace-only required text fields", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const result = validateWorksheet(
+      worksheet,
+      completeOperationValues({
+        combatElement: "   ",
+      }),
+    );
+
+    expect(result.isComplete).toBe(false);
+    expect(result.fields.combatElement).toBe(false);
+  });
+
+  test("only validates medal-specific fields present in the resolved worksheet", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal With Valor"),
+    );
+
+    const result = validateWorksheet(
+      worksheet,
+      completeOperationValues({
+        actionCharacter: "",
+        scope: "",
+      }),
+    );
+
+    expect(result.fields.actionCharacter).toBeUndefined();
+    expect(result.fields.scope).toBeUndefined();
+    expect(result.isComplete).toBe(true);
+  });
+
+  test("requires Purple Heart Scope because the resolved worksheet declares it", () => {
+    const worksheet = resolveMedalWorksheet(getMedal("Purple Heart"));
+
+    const result = validateWorksheet(
+      worksheet,
+      completeOperationValues({
+        actionCharacter: "",
+        scope: "",
+      }),
+    );
+
+    expect(result.isComplete).toBe(false);
+    expect(result.fields.scope).toBe(false);
+  });
+
+  test("rejects a future Operation Date", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    const result = validateWorksheet(
+      worksheet,
+      completeOperationValues({
+        operationDate: tomorrow.toLocaleDateString("en-CA"),
+      }),
+    );
+
+    expect(result.isComplete).toBe(false);
+    expect(result.fields.operationDate).toBe(false);
+  });
+
+  test("treats a missing required field value as invalid", () => {
+    const worksheet = resolveMedalWorksheet(
+      getMedal("Army Commendation Medal"),
+    );
+
+    const values = completeOperationValues();
+    delete values.combatElement;
+
+    const result = validateWorksheet(worksheet, values);
+
+    expect(result.isComplete).toBe(false);
+    expect(result.fields.combatElement).toBe(false);
+  });
+
+  test("fails closed when no worksheet is provided", () => {
+    const result = validateWorksheet(null, completeOperationValues());
+
+    expect(result).toEqual({
+      fields: {},
+      isComplete: false,
+    });
+  });
+
+  test("fails closed for an unsupported required field type", () => {
+    const worksheet = {
+      fields: {
+        unsupportedField: {
+          type: "unsupported",
+          required: true,
+        },
+      },
+    };
+
+    const result = validateWorksheet(worksheet, {
+      unsupportedField: "value",
+    });
+
+    expect(result.isComplete).toBe(false);
+    expect(result.fields.unsupportedField).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up architecture refactor addressing the worksheet/citation concerns from the Operation Medal review in #207.
This PR does not add a new award category or intentionally change existing Operation Medal behavior. This PR also retains the current SOP inconsistencies identified in the previous build.

**Changes**
- Introduces a reusable `operationIndividual` worksheet profile.
- Makes the resolved worksheet the shared source for:
  - field rendering
  - validation/completeness
  - award-change reset/preserve behavior
- Keeps medal definitions focused on medal-specific differences rather than repeating common Operation fields.
- Separates Combat Element semantics from presentation labels.
- Makes Action Character and Scope explicitly different option types:
  - Action Character uses citation-ready choices.
  - Scope uses semantic IDs with exhaustive handling.
- Moves citation construction into shared named builders:
  - 6 opening patterns
  - 5 closing patterns
- Adds fail-closed behavior for unsupported worksheet profiles, field types, citation choices, and Purple Heart Scope values.
- Adds focused pure unit coverage for worksheet resolution and worksheet validation.

**Verification**
- Full Vitest suite green.
- Targeted mutation testing:
  - award-change/reset logic: 14/14 killed
  - worksheet validation: 31/31 killed
  - Purple Heart Scope handling: 8/8 killed
  - worksheet resolution/citation-choice handling: 57/57 killed
  - both citation-builder mutation passes: 100%
- `git diff --check` clean.

This should leave the Medal Recommendation Aid on a cleaner foundation for the upcoming test-suite cleanup.